### PR TITLE
Bind reservations to their hotel's tenant (scope reads/writes, harden create)

### DIFF
--- a/CLIENT/src/pages/auth/ResetPasswordPage.tsx
+++ b/CLIENT/src/pages/auth/ResetPasswordPage.tsx
@@ -29,7 +29,7 @@ const ResetPasswordPage: React.FC = () => {
 
   const onSubmit = async (data: ResetForm) => {
     try {
-      await authService.resetPassword(token, data.password);
+      await authService.resetPassword({ token, newPassword: data.password });
       setDone(true);
     } catch {
       toast.error('Reset link is invalid or expired. Please request a new one.');

--- a/CLIENT/src/pages/bookings/BookingPage.tsx
+++ b/CLIENT/src/pages/bookings/BookingPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link, useParams, useNavigate } from 'react-router-dom';
+import { Link, useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { useForm } from 'react-hook-form';
 import { ChevronLeft, BedDouble, Users, Calendar, CheckCircle, CreditCard, Phone, Mail, User } from 'lucide-react';
@@ -24,7 +24,11 @@ interface GuestForm {
 
 const BookingPage: React.FC = () => {
   const { roomId } = useParams<{ roomId: string }>();
-  void roomId;
+  // The hotel context arrives from the hotel's own landing page; the API binds
+  // the reservation's companyId from hotelId server-side.
+  const [searchParams] = useSearchParams();
+  const hotelId = searchParams.get('hotelId') ?? ROOM.hotelId;
+  const hotelSlug = searchParams.get('h') ?? '';
   const navigate = useNavigate();
   const [checkIn, setCheckIn] = useState('');
   const [checkOut, setCheckOut] = useState('');
@@ -45,11 +49,22 @@ const BookingPage: React.FC = () => {
   const onSubmit = async (data: GuestForm) => {
     if (!checkIn || !checkOut || nights < 1) { toast.error('Please select valid check-in and check-out dates.'); return; }
     setLoading(true);
+    // Tenant-bound reservation payload. companyId is intentionally NOT sent —
+    // the API derives it from hotelId so a booking can't be spoofed onto another
+    // hotel/tenant.
+    const payload = {
+      hotelId,
+      roomId,
+      dateIn: checkIn,
+      dateOut: checkOut,
+      guestCount: Number(guests),
+      guest: data,
+    };
+    void payload; // TODO: submit via reservationService.createReservation once the client API layer is wired
     // Simulate API
     await new Promise((r) => setTimeout(r, 1500));
     setLoading(false);
     setConfirmed(true);
-    void data;
   };
 
   if (confirmed) {
@@ -78,7 +93,7 @@ const BookingPage: React.FC = () => {
     <div className="min-h-screen bg-gray-50">
       <div className="bg-white border-b border-gray-100">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-5 flex items-center gap-3">
-          <Link to={`/hotels/${ROOM.hotelId}`} className="flex items-center gap-1.5 text-gray-500 hover:text-primary-600 text-sm font-medium transition-colors">
+          <Link to={hotelSlug ? `/h/${hotelSlug}` : '/'} className="flex items-center gap-1.5 text-gray-500 hover:text-primary-600 text-sm font-medium transition-colors">
             <ChevronLeft className="h-4 w-4" /> Back
           </Link>
           <span className="text-gray-300">/</span>

--- a/CLIENT/src/pages/hotels/HotelLandingPage.tsx
+++ b/CLIENT/src/pages/hotels/HotelLandingPage.tsx
@@ -183,7 +183,9 @@ const HotelLandingPage: React.FC = () => {
                     </div>
                     {room.id ? (
                       <Link
-                        to={`/book/${room.id}`}
+                        // Carry the hotel context so the booking binds to this
+                        // tenant (the API derives companyId from hotelId).
+                        to={`/book/${room.id}?hotelId=${(hotel as any).id}&h=${slug ?? ''}`}
                         className="rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-[#0F2444] hover:bg-amber-400 transition-colors"
                       >
                         Book

--- a/CLIENT/src/pages/user/SettingsPage.tsx
+++ b/CLIENT/src/pages/user/SettingsPage.tsx
@@ -118,7 +118,7 @@ const SettingsPage: React.FC = () => {
               <button className="text-xs text-primary-600 hover:text-primary-700 font-semibold transition-colors">Manage</button>
             </Row>
             <Row label="Download my data" desc="Get a copy of all your account data">
-              <button onClick={() => toast.success('Data export requested. You'll receive an email shortly.')} className="text-xs text-primary-600 hover:text-primary-700 font-semibold transition-colors">
+              <button onClick={() => toast.success(`Data export requested. You'll receive an email shortly.`)} className="text-xs text-primary-600 hover:text-primary-700 font-semibold transition-colors">
                 Request
               </button>
             </Row>

--- a/controllers/reservationController.ts
+++ b/controllers/reservationController.ts
@@ -19,21 +19,57 @@ const resolveCompanyScope = (req: Request): string | null => {
   return user.companyId || null;
 };
 
+/**
+ * Whether the requester may access a given reservation.
+ * - Platform admin ('admin'): every tenant.
+ * - Hotel staff (org_admin/staff): only reservations for their own company.
+ * - Guest: only their own reservations.
+ */
+const canAccessReservation = (req: Request, reservation: any): boolean => {
+  const user = req.user;
+  if (!user) return false;
+  if (user.type === 'admin') return true;
+  if (user.companyId && reservation.companyId === user.companyId) return true;
+  return reservation.userId === user.id;
+};
+
+// Fields that must never be set from the client body — they are derived from
+// the hotel / authenticated user or controlled by dedicated endpoints.
+const RESERVATION_PROTECTED_FIELDS = ['id', 'companyId', 'userId', 'status', 'checkInTime', 'checkOutTime'];
+
+const stripProtectedFields = (body: Record<string, any>): Record<string, any> => {
+  const clean = { ...body };
+  for (const field of RESERVATION_PROTECTED_FIELDS) delete clean[field];
+  return clean;
+};
+
 export const createReservation = async (req: Request, res: Response): Promise<any> => {
   try {
     const userId = req.user?.id;
     if (!userId) return res.status(401).json({ message: 'Unauthorized' });
 
     const { hotelId, roomId, dateIn, dateOut, guestCount } = req.body;
+    if (!hotelId || !roomId) {
+      return res.status(400).json({ message: 'hotelId and roomId are required' });
+    }
 
     const hotel = await Hotel.findByPk(hotelId);
     if (!hotel) return res.status(404).json({ message: 'Hotel not found' });
 
+    // The room must belong to the hotel being booked, so the reservation binds
+    // to a single, consistent tenant.
+    const room = await Room.findByPk(roomId);
+    if (!room || (room as any).hotelId !== hotelId) {
+      return res.status(400).json({ message: 'Room does not belong to the specified hotel' });
+    }
+
     const companyId = (hotel as any).companyId;
-    const id = uuidv4();
 
     const reservation = await Reservation.create({
-      id,
+      // Client-supplied extras first, then authoritative fields override them so
+      // companyId/userId/status can never be spoofed via the request body.
+      ...stripProtectedFields(req.body),
+      id: uuidv4(),
       userId,
       hotelId,
       roomId,
@@ -42,7 +78,6 @@ export const createReservation = async (req: Request, res: Response): Promise<an
       dateOut,
       guestCount: guestCount || 1,
       status: 'pending',
-      ...req.body,
     });
 
     return res.status(201).json({ message: 'Reservation created successfully', reservation });
@@ -55,7 +90,11 @@ export const getOneReservation = async (req: Request, res: Response): Promise<an
   try {
     const { id } = req.params;
     const reservation = await Reservation.findOne({ where: { id }, include: GUEST_INCLUDE });
-    if (!reservation) return res.status(404).json({ message: 'Reservation not found' });
+    // 404 rather than 403 when the requester has no access, so reservation
+    // existence isn't leaked across tenants.
+    if (!reservation || !canAccessReservation(req, reservation)) {
+      return res.status(404).json({ message: 'Reservation not found' });
+    }
     return res.status(200).json({ message: 'Reservation retrieved', reservation });
   } catch (err: any) {
     return res.status(500).json({ message: 'Failed to retrieve reservation', error: err.message });
@@ -67,7 +106,9 @@ export const lookupReservation = async (req: Request, res: Response): Promise<an
   try {
     const { id } = req.params;
     const reservation = await Reservation.findOne({ where: { id }, include: GUEST_INCLUDE });
-    if (!reservation) return res.status(404).json({ message: 'Booking not found. Please verify the booking number.' });
+    if (!reservation || !canAccessReservation(req, reservation)) {
+      return res.status(404).json({ message: 'Booking not found. Please verify the booking number.' });
+    }
     return res.status(200).json({ message: 'Booking found', reservation });
   } catch (err: any) {
     return res.status(500).json({ message: 'Lookup failed', error: err.message });
@@ -79,7 +120,9 @@ export const checkIn = async (req: Request, res: Response): Promise<any> => {
     const { id } = req.params;
     const reservation = await Reservation.findByPk(id);
 
-    if (!reservation) return res.status(404).json({ message: 'Reservation not found' });
+    if (!reservation || !canAccessReservation(req, reservation)) {
+      return res.status(404).json({ message: 'Reservation not found' });
+    }
     if (reservation.status === 'checked-in') {
       return res.status(409).json({ message: 'Guest is already checked in' });
     }
@@ -107,7 +150,9 @@ export const checkOut = async (req: Request, res: Response): Promise<any> => {
     const { id } = req.params;
     const reservation = await Reservation.findByPk(id);
 
-    if (!reservation) return res.status(404).json({ message: 'Reservation not found' });
+    if (!reservation || !canAccessReservation(req, reservation)) {
+      return res.status(404).json({ message: 'Reservation not found' });
+    }
     if (reservation.status !== 'checked-in') {
       return res.status(409).json({ message: 'Guest must be checked in before checking out' });
     }
@@ -144,10 +189,15 @@ export const getAllReservations = async (req: Request, res: Response): Promise<a
 export const updateReservation = async (req: Request, res: Response): Promise<any> => {
   try {
     const { id } = req.params;
-    const [updated] = await Reservation.update(req.body, { where: { id } });
-    if (updated === 0) return res.status(404).json({ message: 'Reservation not found' });
     const reservation = await Reservation.findByPk(id);
-    return res.status(200).json({ message: 'Reservation updated', reservation });
+    if (!reservation || !canAccessReservation(req, reservation)) {
+      return res.status(404).json({ message: 'Reservation not found' });
+    }
+    // Never allow the tenant/owner/status fields to be reassigned via update;
+    // status transitions go through the dedicated check-in/check-out endpoints.
+    await reservation.update(stripProtectedFields(req.body));
+    const updated = await Reservation.findByPk(id);
+    return res.status(200).json({ message: 'Reservation updated', reservation: updated });
   } catch (err: any) {
     return res.status(500).json({ message: 'Failed to update reservation', error: err.message });
   }
@@ -168,8 +218,11 @@ export const removeAllReservations = async (req: Request, res: Response): Promis
 export const deleteReservation = async (req: Request, res: Response): Promise<any> => {
   try {
     const { id } = req.params;
-    const deleted = await Reservation.destroy({ where: { id } });
-    if (deleted === 0) return res.status(404).json({ message: 'Reservation not found' });
+    const reservation = await Reservation.findByPk(id);
+    if (!reservation || !canAccessReservation(req, reservation)) {
+      return res.status(404).json({ message: 'Reservation not found' });
+    }
+    await reservation.destroy();
     return res.status(200).json({ message: `Reservation ${id} deleted` });
   } catch (err: any) {
     return res.status(500).json({ message: 'Failed to delete reservation', error: err.message });


### PR DESCRIPTION
## Summary

Follow-up to the management-first realignment (PR #9, merged): make every reservation **bind to the right hotel/tenant** and close the cross-tenant read/write holes in the reservation controller. `companyId` is derived server-side from the hotel and can no longer be influenced by client input.

## Backend — `controllers/reservationController.ts`

- **`createReservation`**: the authoritative fields (`id`, `userId`, `companyId`, `status`) are now set **after** spreading the request body, so they can't be spoofed via input. Added validation that the booked room actually belongs to the specified hotel, so a reservation always resolves to one consistent tenant.
- **`canAccessReservation()`** helper — platform admin sees all tenants, hotel staff (`org_admin`) only their own company, guests only their own bookings.
- **`getOneReservation` / `lookupReservation` / `checkIn` / `checkOut`**: now scoped to the requester's tenant. Returns `404` (not `403`) on no-access so cross-tenant existence isn't leaked.
- **`updateReservation` / `deleteReservation`**: previously any authenticated user could edit or delete **any** reservation by id. Now they require access to the reservation, and update strips protected fields so the tenant/owner/status can't be reassigned (status changes go through the check-in/out endpoints).

## Client

- Carry `hotelId` + hotel slug through the `/h/:slug` → `/book/:roomId` navigation so the booking submits the tenant context (the API derives `companyId` from `hotelId`).
- Fix `BookingPage`'s stale link to the retired `/hotels/:id` route.

## Drive-by build fixes (pre-existing breaks on `main`, unrelated to this feature)
The client build was red from an earlier commit; two trivial fixes to make it compile:
- `SettingsPage.tsx` — an unescaped apostrophe (`You'll`) terminated a string literal.
- `ResetPasswordPage.tsx` — `resetPassword()` was called with two args instead of one `PasswordResetData` object.

## Verification
- Backend `tsc --noEmit` — clean.
- Client `tsc --noEmit` — clean (was failing before the two drive-by fixes).

## Note
The client API service layer has a **pre-existing** base-path mismatch with the backend (`/api` prefix, plural vs singular route names), so the frontend isn't live-connected to this server yet — the enforced tenant-binding guarantee lives in the backend. Wiring the client API layer is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adw1AMH3J1UxbBFuQLJ7MS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Adw1AMH3J1UxbBFuQLJ7MS)_