### PR TITLE
Audit: enforce platform-admin vs hotel-admin tenant scoping across controllers

### DIFF
--- a/controllers/authController.ts
+++ b/controllers/authController.ts
@@ -7,8 +7,12 @@ import authService from '../services/authService';
 
 export const register = async (req: Request, res: Response): Promise<any> => {
   try {
-    const { firstName, lastName, email, phoneNumber, password, type, companyId } = req.body;
-    const { token, user } = await authService.register({ firstName, lastName, email, phoneNumber, password, type, companyId });
+    // Public self-signup can NEVER grant an elevated role or attach the account
+    // to a company. `type` and `companyId` from the request body are ignored so
+    // nobody can register themselves as a platform admin or join an arbitrary
+    // tenant. Staff (org_admin) are provisioned through a controlled flow.
+    const { firstName, lastName, email, phoneNumber, password } = req.body;
+    const { token, user } = await authService.register({ firstName, lastName, email, phoneNumber, password, type: 'regular' });
 
     return res.status(201).json({
       message: 'Registration successful',

--- a/controllers/companyController.js
+++ b/controllers/companyController.js
@@ -23,6 +23,11 @@ const companyController = {
 
   getCompany: async (req, res) => {
     try {
+      const { user } = req;
+      // org_admin may only view their own company; platform admin sees any.
+      if (user.type === 'org_admin' && user.companyId !== req.params.id) {
+        return res.status(403).json({ message: 'You can only view your own company' });
+      }
       const company = await companyService.findCompanyById(req.params.id);
       return sendSuccess(res, 'Company found', company);
     } catch (err) {

--- a/controllers/facilityController.ts
+++ b/controllers/facilityController.ts
@@ -4,12 +4,21 @@
 
 import { Request, Response } from 'express';
 import facilityService from '../services/facilityService';
+import { Facility } from '../models';
 
 const resolveCompanyScope = (req: Request): string | undefined => {
   const user = req.user;
   if (!user) return undefined;
   if (user.type === 'admin') return undefined;
   return user.companyId;
+};
+
+/** Platform admin may act on any tenant; anyone else only on their own company. */
+const assertOwns = (req: Request, resourceCompanyId?: string): boolean => {
+  const user = req.user;
+  if (!user) return false;
+  if (user.type === 'admin') return true;
+  return !!resourceCompanyId && user.companyId === resourceCompanyId;
 };
 
 export const createFacility = async (req: Request, res: Response): Promise<any> => {
@@ -47,7 +56,15 @@ export const getAllFacilities = async (req: Request, res: Response): Promise<any
 export const updateFacility = async (req: Request, res: Response): Promise<any> => {
   try {
     const { id } = req.params;
-    const facility = await facilityService.updateFacility(id, req.body);
+    const existing = await Facility.findByPk(id);
+    if (!existing || !assertOwns(req, (existing as any).companyId)) {
+      return res.status(404).json({ message: 'Facility not found' });
+    }
+    // companyId is immutable — never let an update move a facility between tenants.
+    const updateData = { ...req.body };
+    delete updateData.companyId;
+    delete updateData.id;
+    const facility = await facilityService.updateFacility(id, updateData);
     return res.status(200).json({ message: 'Facility updated', facility });
   } catch (err: any) {
     if (err.message === 'Facility not found') return res.status(404).json({ message: err.message });
@@ -58,6 +75,10 @@ export const updateFacility = async (req: Request, res: Response): Promise<any> 
 export const deleteFacility = async (req: Request, res: Response): Promise<any> => {
   try {
     const { id } = req.params;
+    const existing = await Facility.findByPk(id);
+    if (!existing || !assertOwns(req, (existing as any).companyId)) {
+      return res.status(404).json({ message: 'Facility not found' });
+    }
     await facilityService.deleteFacility(id);
     return res.status(200).json({ message: `Facility ${id} deleted successfully` });
   } catch (err: any) {

--- a/controllers/hotelController.ts
+++ b/controllers/hotelController.ts
@@ -126,7 +126,12 @@ export const updateHotel = async (req: Request, res: Response): Promise<any> => 
     if (!(existing as any).companyId || !assertOwnsResource(req, (existing as any).companyId)) {
       return res.status(403).json({ message: 'Forbidden - you do not own this hotel' });
     }
-    const hotel = await hotelService.updateHotel(id, req.body);
+    // companyId is immutable — an owner must not be able to move their hotel to
+    // another tenant.
+    const updateData = { ...req.body };
+    delete updateData.companyId;
+    delete updateData.id;
+    const hotel = await hotelService.updateHotel(id, updateData);
     return res.status(200).json({ message: 'Hotel updated', hotel });
   } catch (err: any) {
     if (err.message.includes('not found')) return res.status(404).json({ message: 'Hotel not found' });

--- a/controllers/ratingsAndReviewController.ts
+++ b/controllers/ratingsAndReviewController.ts
@@ -6,9 +6,21 @@ import { Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { RatingAndReview, Hotel, User } from '../models';
 
+/** Author of the review, a hotel admin for its company, or a platform admin. */
+const canModerateRating = (req: Request, rating: any): boolean => {
+  const user = req.user;
+  if (!user) return false;
+  if (user.type === 'admin') return true;
+  if (user.type === 'org_admin' && user.companyId && rating.companyId === user.companyId) return true;
+  return rating.userId === user.id;
+};
+
 export const createRating = async (req: Request, res: Response): Promise<any> => {
   try {
-    const { userId } = req.params;
+    // Authorship comes from the authenticated user, NOT the URL param, so a
+    // review can't be posted in someone else's name.
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ message: 'Unauthorized' });
     const { hotelId, reviewTitle, review, cleanliness, comfort, service, security, location, overallRating, like } = req.body;
 
     const hotel = await Hotel.findByPk(hotelId);
@@ -60,10 +72,21 @@ export const getRating = async (req: Request, res: Response): Promise<any> => {
 export const updateRating = async (req: Request, res: Response): Promise<any> => {
   try {
     const { id } = req.params;
-    const [updated] = await RatingAndReview.update(req.body, { where: { id } });
-    if (updated === 0) return res.status(404).json({ message: 'Rating not found' });
     const rating = await RatingAndReview.findByPk(id);
-    return res.status(200).json({ message: 'Rating updated', rating });
+    if (!rating) return res.status(404).json({ message: 'Rating not found' });
+    // Only the author (or a platform admin) may edit review content — a hotel
+    // must not be able to rewrite a guest's words.
+    const user = req.user;
+    const isAuthor = !!user && (rating as any).userId === user.id;
+    if (!isAuthor && user?.type !== 'admin') {
+      return res.status(403).json({ message: 'You can only edit your own review' });
+    }
+    // Never let the tenant/author/hotel binding change via update.
+    const updateData = { ...req.body };
+    for (const f of ['id', 'userId', 'companyId', 'hotelId']) delete updateData[f];
+    await rating.update(updateData);
+    const updated = await RatingAndReview.findByPk(id);
+    return res.status(200).json({ message: 'Rating updated', rating: updated });
   } catch (err: any) {
     return res.status(500).json({ message: 'Failed to update rating', error: err.message });
   }
@@ -72,8 +95,13 @@ export const updateRating = async (req: Request, res: Response): Promise<any> =>
 export const deleteRating = async (req: Request, res: Response): Promise<any> => {
   try {
     const { id } = req.params;
-    const deleted = await RatingAndReview.destroy({ where: { id } });
-    if (deleted === 0) return res.status(404).json({ message: 'Rating not found' });
+    const rating = await RatingAndReview.findByPk(id);
+    if (!rating) return res.status(404).json({ message: 'Rating not found' });
+    // Author, the hotel's admin (moderation), or a platform admin may delete.
+    if (!canModerateRating(req, rating)) {
+      return res.status(403).json({ message: 'You do not have permission to delete this review' });
+    }
+    await rating.destroy();
     return res.status(200).json({ message: `Rating ${id} deleted` });
   } catch (err: any) {
     return res.status(500).json({ message: 'Failed to delete rating', error: err.message });

--- a/controllers/roomController.ts
+++ b/controllers/roomController.ts
@@ -13,6 +13,22 @@ const resolveCompanyScope = (req: Request): string | null => {
   return user.companyId || null;
 };
 
+/** Platform admin may act on any tenant; anyone else only on their own company. */
+const assertOwns = (req: Request, resourceCompanyId?: string): boolean => {
+  const user = req.user;
+  if (!user) return false;
+  if (user.type === 'admin') return true;
+  return !!resourceCompanyId && user.companyId === resourceCompanyId;
+};
+
+// Derived from the hotel or immutable — never accepted from the request body.
+const ROOM_PROTECTED_FIELDS = ['id', 'companyId', 'hotelId'];
+const stripProtectedRoomFields = (body: Record<string, any>): Record<string, any> => {
+  const clean = { ...body };
+  for (const field of ROOM_PROTECTED_FIELDS) delete clean[field];
+  return clean;
+};
+
 export const createRoom = async (req: Request, res: Response): Promise<any> => {
   try {
     const { contactEmail, ...roomData } = req.body;
@@ -21,9 +37,13 @@ export const createRoom = async (req: Request, res: Response): Promise<any> => {
     if (!hotel) return res.status(404).json({ message: 'Hotel not found for provided contact email' });
 
     const companyId = (hotel as any).companyId;
+    // The requester must own the hotel they're adding a room to.
+    if (!assertOwns(req, companyId)) {
+      return res.status(403).json({ message: 'You do not have permission to add rooms to this hotel' });
+    }
     const id = uuidv4();
 
-    const room = await Room.create({ id, hotelId: hotel.id, companyId, ...roomData });
+    const room = await Room.create({ id, hotelId: hotel.id, companyId, ...stripProtectedRoomFields(roomData) });
     return res.status(201).json({ message: 'Room created successfully', room });
   } catch (err: any) {
     return res.status(500).json({ message: 'Failed to create room', error: err.message });
@@ -57,10 +77,13 @@ export const getAllRooms = async (req: Request, res: Response): Promise<any> => 
 export const updateRoom = async (req: Request, res: Response): Promise<any> => {
   try {
     const { id } = req.params;
-    const [updated] = await Room.update(req.body, { where: { id } });
-    if (updated === 0) return res.status(404).json({ message: 'Room not found' });
     const room = await Room.findByPk(id);
-    return res.status(200).json({ message: 'Room updated', room });
+    if (!room || !assertOwns(req, (room as any).companyId)) {
+      return res.status(404).json({ message: 'Room not found' });
+    }
+    await room.update(stripProtectedRoomFields(req.body));
+    const updated = await Room.findByPk(id);
+    return res.status(200).json({ message: 'Room updated', room: updated });
   } catch (err: any) {
     return res.status(500).json({ message: 'Failed to update room', error: err.message });
   }
@@ -69,8 +92,11 @@ export const updateRoom = async (req: Request, res: Response): Promise<any> => {
 export const deleteRoom = async (req: Request, res: Response): Promise<any> => {
   try {
     const { id } = req.params;
-    const deleted = await Room.destroy({ where: { id } });
-    if (deleted === 0) return res.status(404).json({ message: 'Room not found' });
+    const room = await Room.findByPk(id);
+    if (!room || !assertOwns(req, (room as any).companyId)) {
+      return res.status(404).json({ message: 'Room not found' });
+    }
+    await room.destroy();
     return res.status(200).json({ message: `Room ${id} deleted successfully` });
   } catch (err: any) {
     return res.status(500).json({ message: 'Failed to delete room', error: err.message });

--- a/controllers/usersController.ts
+++ b/controllers/usersController.ts
@@ -12,6 +12,30 @@ const resolveCompanyScope = (req: Request): string | undefined => {
   return user.companyId;
 };
 
+/**
+ * Whether the requester may act on a given user record.
+ * - Platform admin: any user.
+ * - Hotel admin (org_admin): only users in their own company.
+ * - Everyone else: only their own account.
+ */
+const canAccessUser = (req: Request, target: any): boolean => {
+  const user = req.user;
+  if (!user) return false;
+  if (user.type === 'admin') return true;
+  if (user.type === 'org_admin' && user.companyId && target.companyId === user.companyId) return true;
+  return target.id === user.id;
+};
+
+// Never settable through the generic user-update endpoint: role and tenant
+// changes are privilege boundaries, and password/email have dedicated flows.
+const USER_PROTECTED_FIELDS = ['id', 'type', 'companyId', 'password'];
+
+const stripProtectedUserFields = (body: Record<string, any>): Record<string, any> => {
+  const clean = { ...body };
+  for (const field of USER_PROTECTED_FIELDS) delete clean[field];
+  return clean;
+};
+
 export const findAllUser = async (req: Request, res: Response): Promise<any> => {
   try {
     const companyId = resolveCompanyScope(req);
@@ -26,6 +50,8 @@ export const findOne = async (req: Request, res: Response): Promise<any> => {
   try {
     const { id } = req.params;
     const user = await userService.findUserById(id);
+    // 404 rather than 403 so cross-tenant user existence isn't leaked.
+    if (!canAccessUser(req, user)) return res.status(404).json({ message: 'User not found' });
     return res.status(200).json({ message: 'User retrieved', user });
   } catch (err: any) {
     if (err.message === 'User not found') return res.status(404).json({ message: err.message });
@@ -36,7 +62,11 @@ export const findOne = async (req: Request, res: Response): Promise<any> => {
 export const updateUser = async (req: Request, res: Response): Promise<any> => {
   try {
     const { id } = req.params;
-    const user = await userService.updateUserById(id, req.body);
+    const target = await userService.findUserById(id);
+    if (!canAccessUser(req, target)) return res.status(404).json({ message: 'User not found' });
+    // Strip role/tenant/credential fields so this endpoint can't be used to
+    // escalate privileges or move an account between tenants.
+    const user = await userService.updateUserById(id, stripProtectedUserFields(req.body));
     return res.status(200).json({ message: 'User updated', user });
   } catch (err: any) {
     if (err.message === 'User not found') return res.status(404).json({ message: err.message });
@@ -47,6 +77,8 @@ export const updateUser = async (req: Request, res: Response): Promise<any> => {
 export const deleteUser = async (req: Request, res: Response): Promise<any> => {
   try {
     const { id } = req.params;
+    const target = await userService.findUserById(id);
+    if (!canAccessUser(req, target)) return res.status(404).json({ message: 'User not found' });
     await userService.deleteUserById(id);
     return res.status(200).json({ message: `User ${id} deleted successfully` });
   } catch (err: any) {

--- a/routes/company.js
+++ b/routes/company.js
@@ -5,12 +5,15 @@ const { authentication } = require('../middleware/authentication');
 const authorise = require('../middleware/verifyUserType');
 const companyController = require('../controllers/companyController');
 
+// verifyUserType expects an ARRAY of allowed roles — passing bare strings makes
+// the second role silently ignored (which wrongly blocks org_admin).
 // system admin only — provision a new tenant
-router.post('/companies',         authentication, authorise('admin'), companyController.createCompany);
-// system admin sees all; org_admin gets their own (handled in controller)
-router.get('/companies',          authentication, authorise('admin'), companyController.getAllCompanies);
-router.get('/companies/:id',      authentication, authorise('admin', 'org_admin'), companyController.getCompany);
-router.put('/companies/:id',      authentication, authorise('admin', 'org_admin'), companyController.updateCompany);
-router.delete('/companies/:id',   authentication, authorise('admin'), companyController.deleteCompany);
+router.post('/companies',         authentication, authorise(['admin']), companyController.createCompany);
+// system admin sees all tenants
+router.get('/companies',          authentication, authorise(['admin']), companyController.getAllCompanies);
+// system admin any; org_admin scoped to their own company (enforced in controller)
+router.get('/companies/:id',      authentication, authorise(['admin', 'org_admin']), companyController.getCompany);
+router.put('/companies/:id',      authentication, authorise(['admin', 'org_admin']), companyController.updateCompany);
+router.delete('/companies/:id',   authentication, authorise(['admin']), companyController.deleteCompany);
 
 module.exports = router;


### PR DESCRIPTION
## Summary

The platform-admin vs hotel-admin audit from the realignment plan (§3). A systematic pass over **every** controller to enforce the intended boundary: only a **platform admin** (`type: 'admin'`) may act across tenants; **hotel admins** (`org_admin`) are confined to their own company; guests only to their own records. The reservation fixes (PR #10) proved these gaps existed elsewhere — this closes the rest.

## Privilege escalation (critical)
- **`register`** accepted `type` and `companyId` from the request body — anyone could self-register as a **platform admin** (seeing every tenant) or attach themselves to any company. Public signup now ignores both and always creates a non-privileged `regular` account. *(Staff/org_admin onboarding needs a dedicated controlled flow — see follow-up.)*
- **`updateUser`** required only authentication and passed the body straight through — any user could set their own (or anyone's) `type` to `admin`. Now strips `type`/`companyId`/`password` and is tenant-scoped.
- **`createRating`** trusted the `:userId` URL param for authorship — reviews could be posted in another user's name. Now uses `req.user.id`.

## Cross-tenant reads / writes (previously any authenticated user by id)
| Controller | Before | After |
|---|---|---|
| **users** `findOne`/`update`/`delete` | no scoping | admin=all, org_admin=own company, else self; 404 on no-access |
| **rooms** `create`/`update`/`delete` | no ownership check | assert hotel/room company ownership; strip protected fields |
| **facilities** `update`/`delete` | no ownership check | assert facility company ownership |
| **ratings** `update`/`delete` | no ownership check | update = author/platform admin; delete = author/hotel admin/platform admin |
| **hotels** `update` | `companyId` reassignable | `companyId` stripped (can't transfer hotel to another tenant) |

## Company routes bug
`verifyUserType` expects an **array** of roles, but `company.js` called `authorise('admin', 'org_admin')` with bare string args — the second role was silently ignored, wrongly **blocking `org_admin`** from `getCompany`/`updateCompany`. Fixed to arrays, and `getCompany` now scopes `org_admin` to their own company.

## Verification
- Backend `tsc --noEmit` — clean.

## Follow-up (out of scope here)
Public signup can no longer create hotel staff, so **`org_admin`/company onboarding needs a dedicated controlled endpoint** (e.g. a hotel signs up → creates a company + its first `org_admin`, or an admin invites staff). Worth doing next so the "List your hotel" flow has a real path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adw1AMH3J1UxbBFuQLJ7MS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Adw1AMH3J1UxbBFuQLJ7MS)_