### PR TITLE
Hotel onboarding + staff invite (controlled org_admin creation)

### DIFF
--- a/CLIENT/src/App.tsx
+++ b/CLIENT/src/App.tsx
@@ -12,6 +12,7 @@ import AuthLayout from './components/layout/AuthLayout';
 import HomePage from './pages/HomePage';
 import LoginPage from './pages/auth/LoginPage';
 import RegisterPage from './pages/auth/RegisterPage';
+import OnboardHotelPage from './pages/auth/OnboardHotelPage';
 import ForgotPasswordPage from './pages/auth/ForgotPasswordPage';
 import ResetPasswordPage from './pages/auth/ResetPasswordPage';
 
@@ -82,6 +83,7 @@ const App: React.FC = () => {
           {/* Auth Routes */}
           <Route path="/login" element={<AuthLayout><LoginPage /></AuthLayout>} />
           <Route path="/register" element={<AuthLayout><RegisterPage /></AuthLayout>} />
+          <Route path="/list-your-hotel" element={<AuthLayout><OnboardHotelPage /></AuthLayout>} />
           <Route path="/forgot-password" element={<AuthLayout><ForgotPasswordPage /></AuthLayout>} />
           <Route path="/reset-password" element={<AuthLayout><ResetPasswordPage /></AuthLayout>} />
           

--- a/CLIENT/src/components/layout/MainLayout.tsx
+++ b/CLIENT/src/components/layout/MainLayout.tsx
@@ -152,8 +152,8 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
                 >
                   Sign In
                 </Link>
-                <Link to="/register" className="btn-accent text-sm py-2 px-5">
-                  Get Started
+                <Link to="/list-your-hotel" className="btn-accent text-sm py-2 px-5">
+                  List your hotel
                 </Link>
               </>
             )}
@@ -208,7 +208,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
                   ) : (
                     <div className="flex flex-col space-y-2 px-4">
                       <Link to="/login" className="btn-outline text-center text-sm">Sign In</Link>
-                      <Link to="/register" className="btn-accent text-center text-sm">Get Started</Link>
+                      <Link to="/list-your-hotel" className="btn-accent text-center text-sm">List your hotel</Link>
                     </div>
                   )}
                 </div>
@@ -251,7 +251,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
                   { l: 'Features', to: '/#features' },
                   { l: 'Your booking page', to: '/#booking-page' },
                   { l: 'Sign in', to: '/login' },
-                  { l: 'List your hotel', to: '/register' },
+                  { l: 'List your hotel', to: '/list-your-hotel' },
                 ].map(({ l, to }) => (
                   <li key={l}><Link to={to} className="hover:text-white transition-colors">{l}</Link></li>
                 ))}

--- a/CLIENT/src/pages/HomePage.tsx
+++ b/CLIENT/src/pages/HomePage.tsx
@@ -89,7 +89,7 @@ const HomePage: React.FC = () => {
             </motion.p>
 
             <motion.div variants={fadeUp} className="flex flex-col sm:flex-row items-center justify-center gap-3">
-              <Link to="/register" className="btn-accent py-3 px-7 flex items-center gap-2">
+              <Link to="/list-your-hotel" className="btn-accent py-3 px-7 flex items-center gap-2">
                 List your hotel <ArrowRight className="h-4 w-4" />
               </Link>
               <Link
@@ -245,7 +245,7 @@ const HomePage: React.FC = () => {
               Set up your property and start taking direct bookings today.
             </motion.p>
             <motion.div variants={fadeUp} className="flex flex-col sm:flex-row items-center justify-center gap-3">
-              <Link to="/register" className="btn-accent py-3 px-7 flex items-center gap-2">
+              <Link to="/list-your-hotel" className="btn-accent py-3 px-7 flex items-center gap-2">
                 Get started free <ArrowRight className="h-4 w-4" />
               </Link>
               <Link

--- a/CLIENT/src/pages/auth/OnboardHotelPage.tsx
+++ b/CLIENT/src/pages/auth/OnboardHotelPage.tsx
@@ -1,0 +1,157 @@
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { useForm } from 'react-hook-form';
+import { joiResolver } from '@hookform/resolvers/joi';
+import Joi from 'joi';
+import { Mail, Lock, Eye, EyeOff, User, Phone, Building2, MapPin } from 'lucide-react';
+import { useDispatch } from 'react-redux';
+import { setLoading, loginSuccess, setError } from '../../store/authSlice';
+import { authService } from '../../services';
+import toast from 'react-hot-toast';
+
+interface OnboardForm {
+  hotelName: string;
+  contactEmail: string;
+  address: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phoneNumber: string;
+  password: string;
+  confirmPassword: string;
+}
+
+const schema = Joi.object({
+  hotelName: Joi.string().min(2).required().messages({ 'string.empty': 'Hotel name is required', 'string.min': 'At least 2 characters' }),
+  contactEmail: Joi.string().email({ tlds: { allow: false } }).required().messages({ 'string.email': 'Valid email required', 'string.empty': 'Hotel contact email is required' }),
+  address: Joi.string().allow('').optional(),
+  firstName: Joi.string().min(2).required().messages({ 'string.empty': 'First name is required', 'string.min': 'At least 2 characters' }),
+  lastName: Joi.string().min(2).required().messages({ 'string.empty': 'Last name is required', 'string.min': 'At least 2 characters' }),
+  email: Joi.string().email({ tlds: { allow: false } }).required().messages({ 'string.email': 'Valid email required', 'string.empty': 'Email is required' }),
+  phoneNumber: Joi.string().pattern(/^(?:\+?234|0)\d{10}$/).required().messages({
+    'string.pattern.base': 'Enter a valid Nigerian phone number (e.g. 08012345678)',
+    'string.empty': 'Phone number is required',
+  }),
+  password: Joi.string().min(8).required().messages({ 'string.min': 'Minimum 8 characters', 'string.empty': 'Password is required' }),
+  confirmPassword: Joi.any().valid(Joi.ref('password')).required().messages({ 'any.only': 'Passwords do not match' }),
+});
+
+const InputField = ({ label, error, icon: Icon, children }: {
+  label: string; error?: string; icon: React.ElementType; children: React.ReactNode;
+}) => (
+  <div>
+    <label className="block text-sm font-medium text-gray-700 mb-1.5">{label}</label>
+    <div className="relative">
+      <Icon className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none" style={{ width: '1rem', height: '1rem' }} />
+      {children}
+    </div>
+    {error && (
+      <motion.p initial={{ opacity: 0, y: -4 }} animate={{ opacity: 1, y: 0 }} className="text-red-500 text-xs mt-1">
+        {error}
+      </motion.p>
+    )}
+  </div>
+);
+
+const inputCls = 'w-full pl-10 pr-3.5 py-2.5 rounded-xl border border-gray-200 focus:border-amber-400 focus:ring-2 focus:ring-amber-100 outline-none transition-all text-sm';
+
+const OnboardHotelPage: React.FC = () => {
+  const [showPw, setShowPw] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<OnboardForm>({
+    resolver: joiResolver(schema),
+  });
+
+  const onSubmit = async (data: OnboardForm) => {
+    try {
+      dispatch(setLoading(true));
+      const result = await authService.onboardHotel({
+        company: { name: data.hotelName, contactEmail: data.contactEmail, contactPhone: data.phoneNumber, address: data.address || undefined },
+        admin: { firstName: data.firstName, lastName: data.lastName, email: data.email, phoneNumber: data.phoneNumber, password: data.password },
+      });
+      dispatch(loginSuccess({ token: result.token, user: result.user }));
+      toast.success(`Welcome to StayNG, ${data.hotelName}!`);
+      // New hotel admins go straight to their management console.
+      navigate('/admin');
+    } catch (err: any) {
+      const msg = err?.response?.data?.message ?? 'Onboarding failed. Please try again.';
+      dispatch(setError(msg));
+      toast.error(msg);
+    } finally {
+      dispatch(setLoading(false));
+    }
+  };
+
+  return (
+    <>
+      <div className="mb-8">
+        <h2 className="text-3xl font-display font-bold text-gray-900">List your hotel</h2>
+        <p className="text-gray-500 mt-2 text-sm">Set up your property and your management account — you&apos;ll land straight in your dashboard.</p>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-3">Your property</p>
+          <div className="space-y-4">
+            <InputField label="Hotel / guest house name" error={errors.hotelName?.message} icon={Building2}>
+              <input {...register('hotelName')} className={inputCls} placeholder="ABC Hotels & Suites" />
+            </InputField>
+            <InputField label="Hotel contact email" error={errors.contactEmail?.message} icon={Mail}>
+              <input {...register('contactEmail')} type="email" className={inputCls} placeholder="reservations@abchotels.com" />
+            </InputField>
+            <InputField label="Address (optional)" error={errors.address?.message} icon={MapPin}>
+              <input {...register('address')} className={inputCls} placeholder="Victoria Island, Lagos" />
+            </InputField>
+          </div>
+        </div>
+
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-3">Your admin account</p>
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-3">
+              <InputField label="First name" error={errors.firstName?.message} icon={User}>
+                <input {...register('firstName')} className={inputCls} placeholder="Ada" />
+              </InputField>
+              <InputField label="Last name" error={errors.lastName?.message} icon={User}>
+                <input {...register('lastName')} className={inputCls} placeholder="Obi" />
+              </InputField>
+            </div>
+            <InputField label="Your email" error={errors.email?.message} icon={Mail}>
+              <input {...register('email')} type="email" className={inputCls} placeholder="ada@abchotels.com" />
+            </InputField>
+            <InputField label="Phone number" error={errors.phoneNumber?.message} icon={Phone}>
+              <input {...register('phoneNumber')} className={inputCls} placeholder="08012345678" />
+            </InputField>
+            <InputField label="Password" error={errors.password?.message} icon={Lock}>
+              <input {...register('password')} type={showPw ? 'text' : 'password'} className={inputCls} placeholder="Minimum 8 characters" />
+              <button type="button" onClick={() => setShowPw(!showPw)} className="absolute right-3.5 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors">
+                {showPw ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </InputField>
+            <InputField label="Confirm password" error={errors.confirmPassword?.message} icon={Lock}>
+              <input {...register('confirmPassword')} type={showConfirm ? 'text' : 'password'} className={inputCls} placeholder="Re-enter password" />
+              <button type="button" onClick={() => setShowConfirm(!showConfirm)} className="absolute right-3.5 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors">
+                {showConfirm ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </InputField>
+          </div>
+        </div>
+
+        <button type="submit" disabled={isSubmitting} className="btn-accent w-full py-3 disabled:opacity-60">
+          {isSubmitting ? 'Setting up…' : 'Create my hotel account'}
+        </button>
+      </form>
+
+      <p className="text-center text-sm text-gray-500 mt-6">
+        Already have an account?{' '}
+        <Link to="/login" className="text-primary-600 font-semibold hover:text-primary-700 transition-colors">Sign in</Link>
+      </p>
+    </>
+  );
+};
+
+export default OnboardHotelPage;

--- a/CLIENT/src/services/auth.service.ts
+++ b/CLIENT/src/services/auth.service.ts
@@ -12,6 +12,20 @@ class AuthService {
     return apiService.post<{ token: string; user: User }>(`${this.baseUrl}/register`, data);
   }
 
+  /**
+   * Self-serve hotel onboarding: creates a company + its first org_admin and
+   * returns an auto-login token. This is how a hotel "lists" on StayNG.
+   */
+  async onboardHotel(data: {
+    company: { name: string; contactEmail: string; contactPhone?: string; address?: string };
+    admin: { firstName: string; lastName: string; email: string; phoneNumber?: string; password: string };
+  }) {
+    return apiService.post<{ token: string; user: User; company: { id: string; name: string } }>(
+      '/onboard',
+      data
+    );
+  }
+
   async logout() {
     return apiService.post(`${this.baseUrl}/logout`);
   }

--- a/controllers/authController.ts
+++ b/controllers/authController.ts
@@ -34,6 +34,68 @@ export const register = async (req: Request, res: Response): Promise<any> => {
   }
 };
 
+/**
+ * Public "List your hotel" onboarding: creates a company + its first org_admin
+ * and returns an auto-login token so the owner lands straight in the console.
+ */
+export const onboardHotel = async (req: Request, res: Response): Promise<any> => {
+  try {
+    const { company, admin } = req.body;
+    if (!company?.name || !company?.contactEmail) {
+      return res.status(400).json({ message: 'company.name and company.contactEmail are required' });
+    }
+    if (!admin?.firstName || !admin?.email || !admin?.password) {
+      return res.status(400).json({ message: 'admin.firstName, admin.email and admin.password are required' });
+    }
+
+    const { token, user, company: created } = await authService.onboardCompany(company, admin);
+
+    return res.status(201).json({
+      message: 'Company onboarded successfully',
+      token,
+      user: { id: user.id, firstName: user.firstName, lastName: user.lastName, email: user.email, type: user.type, companyId: user.companyId },
+      company: { id: created.id, name: created.name, contactEmail: created.contactEmail },
+    });
+  } catch (err: any) {
+    if (err.message === 'Email already registered' || err.message?.includes('already exists')) {
+      return res.status(409).json({ message: err.message });
+    }
+    return res.status(500).json({ message: 'Onboarding failed', error: err.message });
+  }
+};
+
+/**
+ * An org_admin (or platform admin) adds a staff account. The company is taken
+ * from the authenticated user — an org_admin can only ever add staff to their
+ * own company, never another tenant.
+ */
+export const inviteStaff = async (req: Request, res: Response): Promise<any> => {
+  try {
+    const requester = req.user;
+    if (!requester) return res.status(401).json({ message: 'Unauthorized' });
+
+    // Platform admin may target any company via body; org_admin is pinned to theirs.
+    const companyId = requester.type === 'admin' ? req.body.companyId : requester.companyId;
+    if (!companyId) {
+      return res.status(400).json({ message: 'A company is required to add staff' });
+    }
+
+    const { firstName, lastName, email, phoneNumber, password, type } = req.body;
+    if (!firstName || !email || !password) {
+      return res.status(400).json({ message: 'firstName, email and password are required' });
+    }
+
+    const user = await authService.createStaff(companyId, { firstName, lastName, email, phoneNumber, password, type });
+    return res.status(201).json({
+      message: 'Staff account created',
+      user: { id: user.id, firstName: user.firstName, lastName: user.lastName, email: user.email, type: user.type, companyId: user.companyId },
+    });
+  } catch (err: any) {
+    if (err.message === 'Email already registered') return res.status(409).json({ message: err.message });
+    return res.status(500).json({ message: 'Failed to create staff account', error: err.message });
+  }
+};
+
 export const login = async (req: Request, res: Response): Promise<any> => {
   try {
     const { email, password } = req.body;

--- a/routes/auth.ts
+++ b/routes/auth.ts
@@ -1,12 +1,17 @@
 import { Router } from 'express';
-import { register, login, logout, forgotPassword, resetPassword } from '../controllers/authController';
+import { register, onboardHotel, inviteStaff, login, logout, forgotPassword, resetPassword } from '../controllers/authController';
 import { authentication } from '../middleware/authentication';
+import verifyUserType from '../middleware/verifyUserType';
 import { validateBody } from '../middleware/validation';
 import { userValidation } from '../src/shared/utils/validationSchemas';
 
 const router = Router();
 
 router.post('/signup', validateBody(userValidation.register), register);
+// Public self-serve: create a company + its first org_admin ("List your hotel").
+router.post('/onboard', onboardHotel);
+// Controlled staff creation, scoped to the requester's company.
+router.post('/staff', authentication, verifyUserType(['admin', 'org_admin']), inviteStaff);
 router.post('/login', validateBody(userValidation.login), login);
 router.post('/logout', authentication, logout);
 router.post('/forgot', forgotPassword);

--- a/services/authService.ts
+++ b/services/authService.ts
@@ -6,7 +6,7 @@ import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import nodemailer from 'nodemailer';
 import { v4 as uuidv4 } from 'uuid';
-import { User } from '../models';
+import { User, Company, sequelize } from '../models';
 import { UserInstance } from '../models/user';
 import { JwtPayload } from '../types';
 
@@ -35,6 +35,81 @@ class AuthService {
 
     const token = this.signToken(user);
     return { token, user };
+  }
+
+  /**
+   * Self-serve hotel onboarding: atomically create a company (tenant) and its
+   * first org_admin, then return an auto-login token. This is the ONLY public
+   * path to an elevated (org_admin) account — plain /signup can't grant it.
+   */
+  async onboardCompany(
+    company: { name: string; contactEmail: string; contactPhone?: string; address?: string },
+    admin: { firstName: string; lastName: string; email: string; phoneNumber?: string; password: string }
+  ): Promise<{ token: string; user: UserInstance; company: any }> {
+    const existingUser = await User.findOne({ where: { email: admin.email } });
+    if (existingUser) throw new Error('Email already registered');
+
+    const existingCompany = await Company.findOne({ where: { contactEmail: company.contactEmail } });
+    if (existingCompany) throw new Error('A company with that contact email already exists');
+
+    const hashedPassword = await bcrypt.hash(admin.password, 10);
+
+    // Wrap both inserts in a transaction so we never leave a company without its
+    // owner (or an owner pointing at a company that failed to create).
+    const result = await sequelize.transaction(async (t) => {
+      const createdCompany = await Company.create(
+        { id: uuidv4(), ...company },
+        { transaction: t }
+      );
+
+      const user = await User.create(
+        {
+          id: uuidv4(),
+          firstName: admin.firstName,
+          lastName: admin.lastName,
+          email: admin.email,
+          phoneNumber: admin.phoneNumber,
+          password: hashedPassword,
+          type: 'org_admin',
+          companyId: (createdCompany as any).id,
+        },
+        { transaction: t }
+      );
+
+      return { createdCompany, user };
+    });
+
+    const token = this.signToken(result.user);
+    return { token, user: result.user, company: result.createdCompany };
+  }
+
+  /**
+   * Create a staff account inside a company. Used by an org_admin to add staff
+   * to their OWN company (companyId is supplied by the controller from the
+   * authenticated user, never the request body). Role is constrained so this
+   * can't mint a platform admin.
+   */
+  async createStaff(
+    companyId: string,
+    staff: { firstName: string; lastName: string; email: string; phoneNumber?: string; password: string; type?: string }
+  ): Promise<UserInstance> {
+    const existing = await User.findOne({ where: { email: staff.email } });
+    if (existing) throw new Error('Email already registered');
+
+    const allowedRoles = ['org_admin', 'regular'];
+    const role = staff.type && allowedRoles.includes(staff.type) ? staff.type : 'org_admin';
+
+    const hashedPassword = await bcrypt.hash(staff.password, 10);
+    return User.create({
+      id: uuidv4(),
+      firstName: staff.firstName,
+      lastName: staff.lastName,
+      email: staff.email,
+      phoneNumber: staff.phoneNumber,
+      password: hashedPassword,
+      type: role as any,
+      companyId,
+    });
   }
 
   async login(email: string, password: string): Promise<{ token: string; user: UserInstance }> {


### PR DESCRIPTION
## Summary

Follow-up the audit (PR #11) created: locking public `/signup` to non-privileged accounts meant hotels had no way into the console. This adds the two **controlled** account-creation flows the audit called for.

## Backend
- **`authService.onboardCompany()`** — atomically (DB transaction) creates a company (tenant) **and** its first `org_admin`, then returns an auto-login token. This is the only public path to an `org_admin` account; if either insert fails, neither persists.
- **`authService.createStaff()`** — creates a staff user inside a company; the role is constrained to `org_admin`/`regular` so it can **never** mint a platform admin.
- **`onboardHotel`** → `POST /onboard` (public, "List your hotel").
- **`inviteStaff`** → `POST /staff` (authenticated, `admin`/`org_admin`). The company is taken from the **authenticated user** — an `org_admin` can only add staff to their own company; only a platform admin may target another via `companyId`.

## Client
- `authService.onboardHotel()`.
- **`OnboardHotelPage`** at `/list-your-hotel` — property details + admin account in one form, auto-login on success, lands in the console (`/admin`).
- Repoint the hotel-owner CTAs (hero, header, footer "List your hotel"/"Get started") from `/register` to `/list-your-hotel`. `/register` stays for guest signup.

## Verification
- Backend `tsc --noEmit` — clean.
- Client `tsc --noEmit` — clean.

## Note
The client API service layer still has the **pre-existing** base-path mismatch with the backend, so the frontend isn't live-connected yet — the onboarding page is wired to the service and ready for when that layer is reconciled. The enforced behaviour lives in the backend endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adw1AMH3J1UxbBFuQLJ7MS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Adw1AMH3J1UxbBFuQLJ7MS)_