### PR TITLE
Guest checkout: book a hotel without an account

### DIFF
--- a/CLIENT/src/pages/bookings/BookingPage.tsx
+++ b/CLIENT/src/pages/bookings/BookingPage.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
-import { Link, useParams, useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { useForm } from 'react-hook-form';
 import { ChevronLeft, BedDouble, Users, Calendar, CheckCircle, CreditCard, Phone, Mail, User } from 'lucide-react';
 import toast from 'react-hot-toast';
+import { reservationService } from '../../services';
 
 // Mock — replace with API call using useParams roomId
 const ROOM = {
@@ -29,12 +30,12 @@ const BookingPage: React.FC = () => {
   const [searchParams] = useSearchParams();
   const hotelId = searchParams.get('hotelId') ?? ROOM.hotelId;
   const hotelSlug = searchParams.get('h') ?? '';
-  const navigate = useNavigate();
   const [checkIn, setCheckIn] = useState('');
   const [checkOut, setCheckOut] = useState('');
   const [guests, setGuests] = useState('1');
   const [payMethod, setPayMethod] = useState<'card' | 'transfer'>('card');
   const [confirmed, setConfirmed] = useState(false);
+  const [bookingReference, setBookingReference] = useState('');
   const [loading, setLoading] = useState(false);
 
   const { register, handleSubmit, formState: { errors } } = useForm<GuestForm>();
@@ -48,23 +49,31 @@ const BookingPage: React.FC = () => {
 
   const onSubmit = async (data: GuestForm) => {
     if (!checkIn || !checkOut || nights < 1) { toast.error('Please select valid check-in and check-out dates.'); return; }
+    if (!roomId) { toast.error('Missing room. Please start from the hotel page.'); return; }
     setLoading(true);
-    // Tenant-bound reservation payload. companyId is intentionally NOT sent —
-    // the API derives it from hotelId so a booking can't be spoofed onto another
-    // hotel/tenant.
-    const payload = {
-      hotelId,
-      roomId,
-      dateIn: checkIn,
-      dateOut: checkOut,
-      guestCount: Number(guests),
-      guest: data,
-    };
-    void payload; // TODO: submit via reservationService.createReservation once the client API layer is wired
-    // Simulate API
-    await new Promise((r) => setTimeout(r, 1500));
-    setLoading(false);
-    setConfirmed(true);
+    try {
+      // Guest checkout — no account required. companyId is intentionally NOT
+      // sent; the API derives it from hotelId so a booking can't be spoofed
+      // onto another hotel/tenant.
+      const result = await reservationService.createGuestReservation({
+        hotelId,
+        roomId,
+        dateIn: checkIn,
+        dateOut: checkOut,
+        guestCount: Number(guests),
+        guest: {
+          name: `${data.firstName} ${data.lastName}`.trim(),
+          email: data.email,
+          phone: data.phone,
+        },
+      });
+      setBookingReference(result.bookingReference);
+      setConfirmed(true);
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message ?? 'Booking failed. Please try again.');
+    } finally {
+      setLoading(false);
+    }
   };
 
   if (confirmed) {
@@ -76,14 +85,20 @@ const BookingPage: React.FC = () => {
           </div>
           <h2 className="text-2xl font-display font-bold text-gray-900 mb-2">Booking Confirmed!</h2>
           <p className="text-gray-500 text-sm mb-6">Your reservation at <span className="font-semibold text-gray-800">{ROOM.hotelName}</span> has been confirmed. A confirmation email is on its way.</p>
+          {bookingReference && (
+            <div className="rounded-2xl border-2 border-dashed border-amber-300 bg-amber-50 p-4 mb-6">
+              <p className="text-xs uppercase tracking-wider text-amber-700 font-semibold mb-1">Your booking reference</p>
+              <p className="text-2xl font-display font-bold text-[#0F2444] tracking-wider">{bookingReference}</p>
+              <p className="text-xs text-gray-500 mt-2">Show this at the front desk to check in.</p>
+            </div>
+          )}
           <div className="bg-gray-50 rounded-2xl p-4 text-sm text-left space-y-2 mb-8">
             <div className="flex justify-between"><span className="text-gray-500">Room</span><span className="font-medium">{ROOM.category}</span></div>
             <div className="flex justify-between"><span className="text-gray-500">Check-in</span><span className="font-medium">{checkIn}</span></div>
             <div className="flex justify-between"><span className="text-gray-500">Check-out</span><span className="font-medium">{checkOut}</span></div>
             <div className="flex justify-between"><span className="text-gray-500">Total</span><span className="font-bold text-primary-700">₦{total.toLocaleString()}</span></div>
           </div>
-          <button onClick={() => navigate('/my-reservations')} className="btn-accent w-full py-3">View My Reservations</button>
-          <Link to="/" className="block text-center text-sm text-gray-500 hover:text-primary-600 mt-4 transition-colors">Back to Home</Link>
+          <Link to={hotelSlug ? `/h/${hotelSlug}` : '/'} className="btn-accent w-full py-3 inline-block">Done</Link>
         </motion.div>
       </div>
     );

--- a/CLIENT/src/services/reservation.service.ts
+++ b/CLIENT/src/services/reservation.service.ts
@@ -24,6 +24,24 @@ class ReservationService {
     return apiService.post<Reservation>(this.baseUrl, reservationData);
   }
 
+  /**
+   * Guest checkout — book a hotel from its public page without an account.
+   * Returns a booking reference the guest presents at the front desk.
+   */
+  async createGuestReservation(data: {
+    hotelId: string;
+    roomId: string;
+    dateIn: string;
+    dateOut: string;
+    guestCount: number;
+    guest: { name: string; email: string; phone?: string };
+  }) {
+    return apiService.post<{ bookingReference: string; reservation: Reservation }>(
+      '/reservation/guest',
+      data
+    );
+  }
+
   async updateReservation(id: string, reservationData: Partial<Reservation>) {
     return apiService.put<Reservation>(`${this.baseUrl}/${id}`, reservationData);
   }

--- a/controllers/reservationController.ts
+++ b/controllers/reservationController.ts
@@ -86,6 +86,92 @@ export const createReservation = async (req: Request, res: Response): Promise<an
   }
 };
 
+/** Generate a short, human-friendly booking reference unique across reservations. */
+const generateBookingReference = async (): Promise<string> => {
+  const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // no ambiguous 0/O/1/I
+  for (let attempt = 0; attempt < 6; attempt++) {
+    let code = '';
+    for (let i = 0; i < 8; i++) code += alphabet[Math.floor(Math.random() * alphabet.length)];
+    const reference = `BK-${code}`;
+    const clash = await Reservation.findOne({ where: { bookingReference: reference }, paranoid: false });
+    if (!clash) return reference;
+  }
+  // Extremely unlikely; fall back to a UUID-derived reference.
+  return `BK-${uuidv4().split('-')[0].toUpperCase()}`;
+};
+
+/**
+ * Guest checkout — book a hotel from its own public page WITHOUT an account.
+ * The guest supplies their contact details; the reservation binds to the
+ * hotel's tenant (companyId derived from the hotel) and gets a booking
+ * reference the guest presents at the front desk for check-in.
+ */
+export const createGuestReservation = async (req: Request, res: Response): Promise<any> => {
+  try {
+    const { hotelId, roomId, dateIn, dateOut, guestCount, guest } = req.body;
+    if (!hotelId || !roomId) {
+      return res.status(400).json({ message: 'hotelId and roomId are required' });
+    }
+    if (!dateIn || !dateOut) {
+      return res.status(400).json({ message: 'dateIn and dateOut are required' });
+    }
+    const guestName = guest?.name ?? req.body.guestName;
+    const guestEmail = guest?.email ?? req.body.guestEmail;
+    const guestPhone = guest?.phone ?? req.body.guestPhone;
+    if (!guestName || !guestEmail) {
+      return res.status(400).json({ message: 'Guest name and email are required' });
+    }
+
+    const hotel = await Hotel.findByPk(hotelId);
+    if (!hotel) return res.status(404).json({ message: 'Hotel not found' });
+
+    const room = await Room.findByPk(roomId);
+    if (!room || (room as any).hotelId !== hotelId) {
+      return res.status(400).json({ message: 'Room does not belong to the specified hotel' });
+    }
+
+    const bookingReference = await generateBookingReference();
+
+    const reservation = await Reservation.create({
+      id: uuidv4(),
+      userId: null as any, // guest booking — no account
+      hotelId,
+      roomId,
+      companyId: (hotel as any).companyId,
+      guestName,
+      guestEmail,
+      guestPhone,
+      bookingReference,
+      dateIn,
+      dateOut,
+      guestCount: guestCount || 1,
+      status: 'pending',
+    });
+
+    return res.status(201).json({
+      message: 'Booking confirmed',
+      bookingReference,
+      reservation,
+    });
+  } catch (err: any) {
+    return res.status(500).json({ message: 'Failed to create booking', error: err.message });
+  }
+};
+
+/** Front-desk lookup by booking reference (for guest check-in). */
+export const lookupByReference = async (req: Request, res: Response): Promise<any> => {
+  try {
+    const { reference } = req.params;
+    const reservation = await Reservation.findOne({ where: { bookingReference: reference }, include: GUEST_INCLUDE });
+    if (!reservation || !canAccessReservation(req, reservation)) {
+      return res.status(404).json({ message: 'Booking not found. Please verify the reference.' });
+    }
+    return res.status(200).json({ message: 'Booking found', reservation });
+  } catch (err: any) {
+    return res.status(500).json({ message: 'Lookup failed', error: err.message });
+  }
+};
+
 export const getOneReservation = async (req: Request, res: Response): Promise<any> => {
   try {
     const { id } = req.params;

--- a/migrations/20240101000005-add-guest-fields-to-reservations.js
+++ b/migrations/20240101000005-add-guest-fields-to-reservations.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/**
+ * Guest checkout: a guest can book a hotel's own page without an account.
+ * Reservations therefore need optional guest contact fields, a human-friendly
+ * booking reference (for confirmation + front-desk lookup / QR), and a nullable
+ * userId (guest bookings aren't tied to a user account).
+ *
+ * @type {import('sequelize-cli').Migration}
+ */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Reservations', 'guestName', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+    await queryInterface.addColumn('Reservations', 'guestEmail', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+    await queryInterface.addColumn('Reservations', 'guestPhone', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+    await queryInterface.addColumn('Reservations', 'bookingReference', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+    await queryInterface.addIndex('Reservations', ['bookingReference'], {
+      unique: true,
+      name: 'reservations_booking_reference_unique',
+      where: { deletedAt: null },
+    });
+
+    // Guest bookings have no user account.
+    await queryInterface.changeColumn('Reservations', 'userId', {
+      type: Sequelize.UUID,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('Reservations', 'reservations_booking_reference_unique');
+    await queryInterface.removeColumn('Reservations', 'guestName');
+    await queryInterface.removeColumn('Reservations', 'guestEmail');
+    await queryInterface.removeColumn('Reservations', 'guestPhone');
+    await queryInterface.removeColumn('Reservations', 'bookingReference');
+    await queryInterface.changeColumn('Reservations', 'userId', {
+      type: Sequelize.UUID,
+      allowNull: false,
+    });
+  },
+};

--- a/models/reservation.ts
+++ b/models/reservation.ts
@@ -7,10 +7,15 @@ import { Model, DataTypes, Sequelize, Optional } from 'sequelize';
 export interface ReservationInstance extends Model {
   id: string;
   hotelId: string;
-  userId: string;
+  userId?: string;
   roomId: string;
   companyId?: string;
   guestCount?: number;
+  // Guest-checkout contact details (used when there is no user account).
+  guestName?: string;
+  guestEmail?: string;
+  guestPhone?: string;
+  bookingReference?: string;
   dateIn: Date;
   dateOut: Date;
   status: 'pending' | 'confirmed' | 'checked-in' | 'checked-out' | 'cancelled' | 'no-show';
@@ -24,7 +29,7 @@ export interface ReservationInstance extends Model {
 
 export interface ReservationCreationAttributes extends Optional<
   ReservationInstance,
-  'id' | 'status' | 'paymentStatus' | 'companyId' | 'guestCount' | 'checkInTime' | 'checkOutTime' | 'createdAt' | 'updatedAt' | 'deletedAt'
+  'id' | 'status' | 'paymentStatus' | 'companyId' | 'guestCount' | 'userId' | 'guestName' | 'guestEmail' | 'guestPhone' | 'bookingReference' | 'checkInTime' | 'checkOutTime' | 'createdAt' | 'updatedAt' | 'deletedAt'
 > {}
 
 export default (sequelize: Sequelize, dataTypes: typeof DataTypes): any => {
@@ -37,10 +42,14 @@ export default (sequelize: Sequelize, dataTypes: typeof DataTypes): any => {
 
     id!: string;
     hotelId!: string;
-    userId!: string;
+    userId?: string;
     roomId!: string;
     companyId?: string;
     guestCount?: number;
+    guestName?: string;
+    guestEmail?: string;
+    guestPhone?: string;
+    bookingReference?: string;
     dateIn!: Date;
     dateOut!: Date;
     status!: 'pending' | 'confirmed' | 'checked-in' | 'checked-out' | 'cancelled' | 'no-show';
@@ -66,12 +75,29 @@ export default (sequelize: Sequelize, dataTypes: typeof DataTypes): any => {
       },
       userId: {
         type: dataTypes.UUID,
-        allowNull: false,
+        allowNull: true,
       },
       roomId: {
         type: dataTypes.UUID,
         allowNull: false,
         validate: { notNull: { msg: 'Room must not be empty' } },
+      },
+      guestName: {
+        type: dataTypes.STRING,
+        allowNull: true,
+      },
+      guestEmail: {
+        type: dataTypes.STRING,
+        allowNull: true,
+      },
+      guestPhone: {
+        type: dataTypes.STRING,
+        allowNull: true,
+      },
+      bookingReference: {
+        type: dataTypes.STRING,
+        allowNull: true,
+        unique: true,
       },
       companyId: {
         type: dataTypes.UUID,

--- a/routes/reservation.ts
+++ b/routes/reservation.ts
@@ -1,8 +1,10 @@
 import { Router } from 'express';
 import {
   createReservation,
+  createGuestReservation,
   getOneReservation,
   lookupReservation,
+  lookupByReference,
   checkIn,
   checkOut,
   getAllReservations,
@@ -16,11 +18,14 @@ import verifyUserType from '../middleware/verifyUserType';
 const router = Router();
 
 router.post('/reservation', authentication, createReservation);
+// Guest checkout — book from a hotel's public page without an account.
+router.post('/reservation/guest', createGuestReservation);
 router.get('/getone/:id', authentication, getOneReservation);
 router.get('/getall', authentication, getAllReservations);
 
-// Front-desk: look up any booking by ID (admin/org_admin)
+// Front-desk: look up any booking by ID or by guest booking reference (admin/org_admin)
 router.get('/lookup/:id', authentication, verifyUserType(['admin', 'org_admin']), lookupReservation);
+router.get('/lookup-ref/:reference', authentication, verifyUserType(['admin', 'org_admin']), lookupByReference);
 
 // Check-in / check-out (front desk only)
 router.put('/checkin/:id', authentication, verifyUserType(['admin', 'org_admin']), checkIn);


### PR DESCRIPTION
## Summary

The last item from the realignment plan: **guest checkout**. A guest can book from a hotel's own `/h/:slug` page **without creating an account** — the lightweight guest model we agreed on (name/phone/email at booking, a booking reference instead of a full account).

## Backend
- **Reservation model + migration `20240101000005`**: `userId` is now nullable (guest bookings aren't tied to an account), plus guest contact fields (`guestName`/`guestEmail`/`guestPhone`) and a unique `bookingReference`.
- **`POST /reservation/guest`** (public): validates the room belongs to the hotel, derives `companyId` from the hotel (so a guest booking can't be spoofed onto another tenant — same guarantee as PR #10), stores the guest's contact details, generates a booking reference, and returns it.
- **`GET /lookup-ref/:reference`** (`admin`/`org_admin`, tenant-scoped via `canAccessReservation`): front-desk lookup of a guest booking by its reference for check-in.

## Client
- `reservationService.createGuestReservation()`.
- `BookingPage` now submits a real guest booking and shows the returned **booking reference** prominently (what the guest presents at the front desk). Replaced the account-only "View My Reservations" CTA with a return-to-hotel link, since guests have no account.

## Verification
- Backend `tsc --noEmit` — clean.
- Client `tsc --noEmit` — clean.

## Notes
- Migration `20240101000005-add-guest-fields-to-reservations.js` must be run (`npm run migrate`).
- The client API layer still has the pre-existing base-path mismatch, so the page is wired to the service but won't hit the server until that's reconciled — **which is the very next task** (client API wiring). Guest checkout is built on top so it works the moment the layer is connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adw1AMH3J1UxbBFuQLJ7MS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Adw1AMH3J1UxbBFuQLJ7MS)_