### PR TITLE
Wire client API layer to the backend

### DIFF
--- a/CLIENT/src/pages/admin/FrontDeskPage.tsx
+++ b/CLIENT/src/pages/admin/FrontDeskPage.tsx
@@ -38,7 +38,10 @@ const FrontDeskPage: React.FC = () => {
     setNotFound(false);
     setReservation(null);
     try {
-      const res: any = await reservationService.lookupReservation(trimmed);
+      // Guest bookings are found by their BK- reference; staff bookings by id.
+      const res: any = /^BK-/i.test(trimmed)
+        ? await reservationService.lookupByReference(trimmed.toUpperCase())
+        : await reservationService.lookupReservation(trimmed);
       setReservation(res?.reservation || res);
     } catch {
       setNotFound(true);

--- a/CLIENT/src/services/api.ts
+++ b/CLIENT/src/services/api.ts
@@ -6,7 +6,10 @@ class ApiService {
 
   constructor() {
     this.api = axios.create({
-      baseURL: import.meta.env.VITE_API_URL || 'http://localhost:3360/api',
+      // Defaults to the backend's default port (LOCAL_PORT || 3000). Override
+      // with VITE_API_URL to point at another host/port. The backend mounts all
+      // API routes under /api.
+      baseURL: import.meta.env.VITE_API_URL || 'http://localhost:3000/api',
       timeout: 30000,
       headers: {
         'Content-Type': 'application/json',

--- a/CLIENT/src/services/auth.service.ts
+++ b/CLIENT/src/services/auth.service.ts
@@ -1,15 +1,24 @@
 import apiService from './api';
 import type { LoginCredentials, RegisterData, User, PasswordResetData } from '@/types';
 
+// The backend returns the user's role as `type`; the client reads `userType`
+// (ProtectedRoute, login redirect). Normalise so both names are present.
+const normalizeUser = (user: any): User => (
+  user ? { ...user, userType: user.userType ?? user.type } : user
+);
+
 class AuthService {
-  private baseUrl = '/auth';
+  // Routes are mounted at the API root (see backend routes/auth.ts), e.g.
+  // /login, /signup — the axios instance already prefixes /api.
 
   async login(credentials: LoginCredentials) {
-    return apiService.post<{ token: string; user: User }>(`${this.baseUrl}/login`, credentials);
+    const res = await apiService.post<{ token: string; user: any }>('/login', credentials);
+    return { ...res, user: normalizeUser(res.user) };
   }
 
   async register(data: RegisterData) {
-    return apiService.post<{ token: string; user: User }>(`${this.baseUrl}/register`, data);
+    const res = await apiService.post<{ token: string; user: any }>('/signup', data);
+    return { ...res, user: normalizeUser(res.user) };
   }
 
   /**
@@ -20,30 +29,27 @@ class AuthService {
     company: { name: string; contactEmail: string; contactPhone?: string; address?: string };
     admin: { firstName: string; lastName: string; email: string; phoneNumber?: string; password: string };
   }) {
-    return apiService.post<{ token: string; user: User; company: { id: string; name: string } }>(
+    const res = await apiService.post<{ token: string; user: any; company: { id: string; name: string } }>(
       '/onboard',
       data
     );
+    return { ...res, user: normalizeUser(res.user) };
   }
 
   async logout() {
-    return apiService.post(`${this.baseUrl}/logout`);
+    return apiService.post('/logout');
   }
 
   async forgotPassword(email: string) {
-    return apiService.post(`${this.baseUrl}/forgot-password`, { email });
+    return apiService.post('/forgot', { email });
   }
 
   async resetPassword(data: PasswordResetData) {
-    return apiService.post(`${this.baseUrl}/reset-password`, data);
-  }
-
-  async verifyEmail(token: string) {
-    return apiService.post(`${this.baseUrl}/verify-email`, { token });
-  }
-
-  async getCurrentUser() {
-    return apiService.get<User>('/users/me');
+    // Backend takes the token in the URL and the new password in the body.
+    return apiService.post(`/reset/${data.token}`, {
+      newPassword: data.newPassword,
+      confirmPassword: data.newPassword,
+    });
   }
 
   setAuthToken(token: string) {

--- a/CLIENT/src/services/hotel.service.ts
+++ b/CLIENT/src/services/hotel.service.ts
@@ -1,15 +1,19 @@
 import apiService from './api';
 import type { Hotel, HotelSearchFilters, PaginatedResponse, PaginationParams } from '@/types';
 
+/**
+ * Paths map to the backend routes/hotel.ts. The axios instance prefixes /api.
+ * The listing/discovery routes require authentication (staff only); the
+ * by-slug and findone routes are the public, single-hotel surfaces.
+ */
 class HotelService {
-  private baseUrl = '/hotels';
-
+  /** Staff-only: list hotels scoped to the caller's company (platform admin: all). */
   async getAllHotels(params?: HotelSearchFilters & PaginationParams) {
-    return apiService.get<PaginatedResponse<Hotel>>(this.baseUrl, { params });
+    return apiService.get<PaginatedResponse<Hotel>>('/findall', { params });
   }
 
   async getHotelById(id: string) {
-    return apiService.get<Hotel>(`${this.baseUrl}/${id}`);
+    return apiService.get<{ hotel: Hotel }>(`/findone/${id}`);
   }
 
   /** Public per-hotel landing page — resolves a single hotel by its slug. */
@@ -18,27 +22,15 @@ class HotelService {
   }
 
   async createHotel(hotelData: Partial<Hotel>) {
-    return apiService.post<Hotel>(this.baseUrl, hotelData);
+    return apiService.post<{ hotel: Hotel }>('/createhotel', hotelData);
   }
 
   async updateHotel(id: string, hotelData: Partial<Hotel>) {
-    return apiService.put<Hotel>(`${this.baseUrl}/${id}`, hotelData);
+    return apiService.put<{ hotel: Hotel }>(`/update/${id}`, hotelData);
   }
 
   async deleteHotel(id: string) {
-    return apiService.delete(`${this.baseUrl}/${id}`);
-  }
-
-  async searchHotels(filters: HotelSearchFilters) {
-    return apiService.get<PaginatedResponse<Hotel>>(`${this.baseUrl}/search`, { params: filters });
-  }
-
-  async getHotelsByCity(city: string) {
-    return apiService.get<PaginatedResponse<Hotel>>(`${this.baseUrl}/city/${city}`);
-  }
-
-  async getPopularHotels(limit?: number) {
-    return apiService.get<Hotel[]>(`${this.baseUrl}/popular`, { params: { limit } });
+    return apiService.delete(`/delete/${id}`);
   }
 }
 

--- a/CLIENT/src/services/reservation.service.ts
+++ b/CLIENT/src/services/reservation.service.ts
@@ -1,27 +1,21 @@
 import apiService from './api';
 import type { Reservation, CreateReservationRequest, PaginationParams, PaginatedResponse } from '@/types';
 
+/**
+ * Paths map to the backend routes/reservation.ts. The axios instance already
+ * prefixes /api, so paths here are relative to the API root.
+ */
 class ReservationService {
-  private baseUrl = '/reservations';
-
   async getAllReservations(params?: PaginationParams) {
-    return apiService.get<PaginatedResponse<Reservation>>(this.baseUrl, { params });
+    return apiService.get<PaginatedResponse<Reservation>>('/getall', { params });
   }
 
   async getReservationById(id: string) {
-    return apiService.get<Reservation>(`${this.baseUrl}/${id}`);
-  }
-
-  async getUserReservations(userId: string, params?: PaginationParams) {
-    return apiService.get<PaginatedResponse<Reservation>>(`${this.baseUrl}/user/${userId}`, { params });
-  }
-
-  async getCurrentUserReservations(params?: PaginationParams) {
-    return apiService.get<PaginatedResponse<Reservation>>(`${this.baseUrl}/my-reservations`, { params });
+    return apiService.get<{ reservation: Reservation }>(`/getone/${id}`);
   }
 
   async createReservation(reservationData: CreateReservationRequest) {
-    return apiService.post<Reservation>(this.baseUrl, reservationData);
+    return apiService.post<{ reservation: Reservation }>('/reservation', reservationData);
   }
 
   /**
@@ -43,38 +37,29 @@ class ReservationService {
   }
 
   async updateReservation(id: string, reservationData: Partial<Reservation>) {
-    return apiService.put<Reservation>(`${this.baseUrl}/${id}`, reservationData);
-  }
-
-  async cancelReservation(id: string) {
-    return apiService.patch<Reservation>(`${this.baseUrl}/${id}/cancel`);
-  }
-
-  async confirmReservation(id: string) {
-    return apiService.patch<Reservation>(`${this.baseUrl}/${id}/confirm`);
+    return apiService.put<{ reservation: Reservation }>(`/updatereservation/${id}`, reservationData);
   }
 
   async deleteReservation(id: string) {
-    return apiService.delete(`${this.baseUrl}/${id}`);
+    return apiService.delete(`/deletereservation/${id}`);
   }
 
-  async checkAvailability(roomId: string, checkIn: string, checkOut: string) {
-    return apiService.get<boolean>(`${this.baseUrl}/check-availability`, {
-      params: { roomId, checkIn, checkOut },
-    });
-  }
-
-  /** Front-desk: look up a booking by ID */
+  /** Front-desk: look up a booking by reservation ID. */
   async lookupReservation(id: string) {
-    return apiService.get<Reservation>(`/lookup/${id}`);
+    return apiService.get<{ reservation: Reservation }>(`/lookup/${id}`);
+  }
+
+  /** Front-desk: look up a guest booking by its booking reference. */
+  async lookupByReference(reference: string) {
+    return apiService.get<{ reservation: Reservation }>(`/lookup-ref/${reference}`);
   }
 
   async checkIn(id: string) {
-    return apiService.put<Reservation>(`/checkin/${id}`, {});
+    return apiService.put<{ reservation: Reservation }>(`/checkin/${id}`, {});
   }
 
   async checkOut(id: string) {
-    return apiService.put<Reservation>(`/checkout/${id}`, {});
+    return apiService.put<{ reservation: Reservation }>(`/checkout/${id}`, {});
   }
 }
 

--- a/CLIENT/src/services/room.service.ts
+++ b/CLIENT/src/services/room.service.ts
@@ -1,41 +1,26 @@
 import apiService from './api';
-import type { Room, RoomBookingRequest, PaginationParams, PaginatedResponse } from '@/types';
+import type { Room, PaginationParams, PaginatedResponse } from '@/types';
 
+/** Paths map to the backend routes/room.ts. The axios instance prefixes /api. */
 class RoomService {
-  private baseUrl = '/rooms';
-
   async getAllRooms(params?: PaginationParams) {
-    return apiService.get<PaginatedResponse<Room>>(this.baseUrl, { params });
+    return apiService.get<PaginatedResponse<Room>>('/rooms', { params });
   }
 
   async getRoomById(id: string) {
-    return apiService.get<Room>(`${this.baseUrl}/${id}`);
-  }
-
-  async getRoomsByHotel(hotelId: string, params?: PaginationParams) {
-    return apiService.get<PaginatedResponse<Room>>(`${this.baseUrl}/hotel/${hotelId}`, { params });
+    return apiService.get<{ room: Room }>(`/room/${id}`);
   }
 
   async createRoom(roomData: Partial<Room>) {
-    return apiService.post<Room>(this.baseUrl, roomData);
+    return apiService.post<{ room: Room }>('/room', roomData);
   }
 
   async updateRoom(id: string, roomData: Partial<Room>) {
-    return apiService.put<Room>(`${this.baseUrl}/${id}`, roomData);
+    return apiService.put<{ room: Room }>(`/updateroom/${id}`, roomData);
   }
 
   async deleteRoom(id: string) {
-    return apiService.delete(`${this.baseUrl}/${id}`);
-  }
-
-  async checkAvailability(hotelId: string, checkIn: string, checkOut: string, guests?: number) {
-    return apiService.get<Room[]>(`${this.baseUrl}/availability`, {
-      params: { hotelId, checkIn, checkOut, guests },
-    });
-  }
-
-  async bookRoom(bookingRequest: RoomBookingRequest) {
-    return apiService.post(`${this.baseUrl}/book`, bookingRequest);
+    return apiService.delete(`/deleteroom/${id}`);
   }
 }
 

--- a/CLIENT/src/services/user.service.ts
+++ b/CLIENT/src/services/user.service.ts
@@ -1,43 +1,22 @@
 import apiService from './api';
 import type { User, PaginationParams, PaginatedResponse } from '@/types';
 
+/** Paths map to the backend routes/user.ts. The axios instance prefixes /api. */
 class UserService {
-  private baseUrl = '/users';
-
   async getAllUsers(params?: PaginationParams) {
-    return apiService.get<PaginatedResponse<User>>(this.baseUrl, { params });
+    return apiService.get<PaginatedResponse<User>>('/alluser', { params });
   }
 
   async getUserById(id: string) {
-    return apiService.get<User>(`${this.baseUrl}/${id}`);
-  }
-
-  async getCurrentUser() {
-    return apiService.get<User>(`${this.baseUrl}/me`);
-  }
-
-  async createUser(userData: Partial<User>) {
-    return apiService.post<User>(this.baseUrl, userData);
+    return apiService.get<{ user: User }>(`/user/${id}`);
   }
 
   async updateUser(id: string, userData: Partial<User>) {
-    return apiService.put<User>(`${this.baseUrl}/${id}`, userData);
-  }
-
-  async updateCurrentUser(userData: Partial<User>) {
-    return apiService.put<User>(`${this.baseUrl}/me`, userData);
+    return apiService.put<{ user: User }>(`/updateuser/${id}`, userData);
   }
 
   async deleteUser(id: string) {
-    return apiService.delete(`${this.baseUrl}/${id}`);
-  }
-
-  async changePassword(oldPassword: string, newPassword: string) {
-    return apiService.patch(`${this.baseUrl}/change-password`, { oldPassword, newPassword });
-  }
-
-  async uploadProfileImage(file: File) {
-    return apiService.uploadFile<{ url: string }>(`${this.baseUrl}/upload-image`, file);
+    return apiService.delete(`/deleteuser/${id}`);
   }
 }
 

--- a/CLIENT/src/store/authSlice.ts
+++ b/CLIENT/src/store/authSlice.ts
@@ -9,8 +9,11 @@ interface AuthState {
   error: string | null;
 }
 
+const storedUser = localStorage.getItem('user');
+
 const initialState: AuthState = {
-  user: null,
+  // Rehydrate the user so role-based routing (ProtectedRoute) survives reloads.
+  user: storedUser ? JSON.parse(storedUser) : null,
   token: localStorage.getItem('authToken'),
   isAuthenticated: !!localStorage.getItem('authToken'),
   loading: false,
@@ -31,12 +34,15 @@ const authSlice = createSlice({
       state.isAuthenticated = true;
       state.error = null;
       localStorage.setItem('authToken', token);
+      // ProtectedRoute reads the user (and role) from localStorage.
+      localStorage.setItem('user', JSON.stringify(user));
     },
     logout: (state) => {
       state.user = null;
       state.token = null;
       state.isAuthenticated = false;
       localStorage.removeItem('authToken');
+      localStorage.removeItem('user');
     },
     setError: (state, action: PayloadAction<string | null>) => {
       state.error = action.payload;
@@ -47,6 +53,7 @@ const authSlice = createSlice({
     updateUser: (state, action: PayloadAction<Partial<User>>) => {
       if (state.user) {
         state.user = { ...state.user, ...action.payload };
+        localStorage.setItem('user', JSON.stringify(state.user));
       }
     },
   },

--- a/app.ts
+++ b/app.ts
@@ -110,14 +110,16 @@ const upload = multer({
 });
 
 // ── Routes ─────────────────────────────────────────────────────────────────────
-app.use('/', authLimiter, authRoute);
-app.use('/', userRoute);
-app.use('/', hotelRoute);
-app.use('/', roomRoute);
-app.use('/', facilityRoute);
-app.use('/', ratingsRoute);
-app.use('/', reservationRoute);
-app.use('/', companyRoute);
+// All API routes are namespaced under /api; the root path is reserved for the
+// health probe, welcome message, and (later) serving the built frontend.
+app.use('/api', authLimiter, authRoute);
+app.use('/api', userRoute);
+app.use('/api', hotelRoute);
+app.use('/api', roomRoute);
+app.use('/api', facilityRoute);
+app.use('/api', ratingsRoute);
+app.use('/api', reservationRoute);
+app.use('/api', companyRoute);
 
 // Health check (no auth, no rate limit — for load-balancer probes)
 app.get('/health', (_req, res) => {


### PR DESCRIPTION
## Summary

Wires the client service layer to the actual backend. Until now the frontend pointed at idealized REST routes (`/hotels`, `/reservations`, `/auth/login`) that don't exist on the server, so nothing the UI did actually reached the API. This reconciles the two so the live flows work end to end.

## Backend
- **Namespace all API routers under `/api`** (they were mounted at `/`). `/health` and the welcome route stay at root. This matches the client's `/api` base.

## Client — service routes now match the backend
| Service | Real routes |
|---|---|
| auth | `/login`, `/signup`, `/onboard`, `/logout`, `/forgot`, `/reset/:token` |
| hotels | `/findall`, `/findone/:id`, `/hotels/by-slug/:slug`, `/createhotel`, `/update/:id`, `/delete/:id` |
| rooms | `/rooms`, `/room/:id`, `/room`, `/updateroom/:id`, `/deleteroom/:id` |
| users | `/alluser`, `/user/:id`, `/updateuser/:id`, `/deleteuser/:id` |
| reservations | `/getall`, `/getone/:id`, `/reservation`, `/reservation/guest`, `/updatereservation/:id`, `/deletereservation/:id`, `/lookup/:id`, `/lookup-ref/:reference`, `/checkin/:id`, `/checkout/:id` |

Methods with no backend endpoint (search/popular/availability/change-password/verify-email/etc.) were removed to keep the layer honest — none were consumed by live pages.

## Client — fixes that make the live flows actually work
- **Role normalization** — backend returns the role as `type`, the client reads `userType`. The auth service now maps `type → userType`, so the login redirect and `ProtectedRoute`'s console gate work.
- **Persist the user** — the slice only stored `authToken`; `ProtectedRoute` reads the user from `localStorage`, which was never written. Now the user is persisted on login (and rehydrated on load), cleared on logout.
- **Front desk lookup** — guest bookings are found by their `BK-` reference, staff bookings by id.
- **Port** — default API base now targets the backend's default port (`3000`), overridable via `VITE_API_URL`.

## Flows now wired end to end
Login, guest signup, **hotel onboarding → console**, the per-hotel `/h/:slug` landing page, **guest checkout → booking reference**, and **front-desk lookup / check-in / check-out**.

## Verification
- Backend `tsc --noEmit` — clean.
- Client `tsc --noEmit` — clean.

## Notes
- Requires the DB migrations from the earlier PRs to be run (`npm run migrate`).
- Console CRUD pages (manage hotels/rooms/reservations dashboards) are still mock scaffolds — the services they'd use are now correct, so wiring them is a mechanical follow-up. This PR focused on the routes the live flows depend on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adw1AMH3J1UxbBFuQLJ7MS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Adw1AMH3J1UxbBFuQLJ7MS)_