### PR TITLE
Wire admin console dashboards to the live API

### DIFF
--- a/CLIENT/src/pages/admin/AdminDashboardPage.tsx
+++ b/CLIENT/src/pages/admin/AdminDashboardPage.tsx
@@ -1,128 +1,169 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { Building2, BedDouble, CalendarCheck, Users, TrendingUp, ArrowRight, CheckCircle, Clock, X } from 'lucide-react';
+import { Building2, BedDouble, CalendarCheck, Users, ArrowRight, CheckCircle, Clock, X, LogIn, LogOut, Loader2 } from 'lucide-react';
+import { hotelService, roomService, reservationService, userService } from '../../services';
 
 const fadeUp = { hidden: { opacity: 0, y: 16 }, visible: { opacity: 1, y: 0, transition: { duration: 0.4 } } };
 const stagger = { hidden: {}, visible: { transition: { staggerChildren: 0.08 } } };
-
-const STATS = [
-  { label: 'Total Hotels', value: '24', change: '+3 this month', icon: Building2, color: 'text-blue-600', bg: 'bg-blue-50', grad: 'from-blue-500 to-indigo-600' },
-  { label: 'Total Rooms', value: '312', change: '+18 this month', icon: BedDouble, color: 'text-violet-600', bg: 'bg-violet-50', grad: 'from-violet-500 to-purple-600' },
-  { label: 'Reservations', value: '1,840', change: '+124 this month', icon: CalendarCheck, color: 'text-emerald-600', bg: 'bg-emerald-50', grad: 'from-emerald-500 to-teal-600' },
-  { label: 'Registered Users', value: '5,290', change: '+310 this month', icon: Users, color: 'text-accent-600', bg: 'bg-accent-50', grad: 'from-orange-400 to-red-500' },
-];
-
-const RECENT = [
-  { id: 'R092', guest: 'Amaka Nwosu', hotel: 'Eko Hotel & Suites', checkIn: '2026-04-10', status: 'confirmed' },
-  { id: 'R091', guest: 'Tunde Adeyemi', hotel: 'Transcorp Hilton', checkIn: '2026-04-08', status: 'pending' },
-  { id: 'R090', guest: 'Chioma Okafor', hotel: 'Hotel Presidential', checkIn: '2026-04-06', status: 'completed' },
-  { id: 'R089', guest: 'Emeka Eze', hotel: 'Nicon Luxury Hotel', checkIn: '2026-04-05', status: 'cancelled' },
-  { id: 'R088', guest: 'Fatima Bello', hotel: 'Wheatbaker Hotel', checkIn: '2026-04-03', status: 'confirmed' },
-];
 
 const QUICK_LINKS = [
   { to: '/admin/hotels', label: 'Manage Hotels', icon: Building2, desc: 'Add, edit or remove hotels', grad: 'from-blue-500 to-indigo-600' },
   { to: '/admin/rooms', label: 'Manage Rooms', icon: BedDouble, desc: 'Configure room types and pricing', grad: 'from-violet-500 to-purple-600' },
   { to: '/admin/reservations', label: 'Reservations', icon: CalendarCheck, desc: 'Review and process bookings', grad: 'from-emerald-500 to-teal-600' },
-  { to: '/admin/users', label: 'Manage Users', icon: Users, desc: 'View and manage guest accounts', grad: 'from-orange-400 to-red-500' },
+  { to: '/admin/users', label: 'Manage Users', icon: Users, desc: 'View and manage user accounts', grad: 'from-orange-400 to-red-500' },
 ];
 
-const statusIcon: Record<string, React.ElementType> = { confirmed: CheckCircle, pending: Clock, completed: CheckCircle, cancelled: X };
-const statusStyle: Record<string, string> = { confirmed: 'bg-emerald-100 text-emerald-700', pending: 'bg-amber-100 text-amber-700', completed: 'bg-blue-100 text-blue-700', cancelled: 'bg-red-100 text-red-600' };
+const statusIcon: Record<string, React.ElementType> = {
+  confirmed: CheckCircle, pending: Clock, 'checked-in': LogIn, 'checked-out': LogOut, cancelled: X, 'no-show': X,
+};
+const statusStyle: Record<string, string> = {
+  confirmed: 'bg-emerald-100 text-emerald-700', pending: 'bg-amber-100 text-amber-700',
+  'checked-in': 'bg-blue-100 text-blue-700', 'checked-out': 'bg-gray-100 text-gray-600',
+  cancelled: 'bg-red-100 text-red-600', 'no-show': 'bg-red-100 text-red-600',
+};
 
-const AdminDashboardPage: React.FC = () => (
-  <div className="min-h-screen bg-gray-50">
-    <div className="bg-white border-b border-gray-100">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <motion.div initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }}>
-          <p className="text-sm text-primary-600 font-semibold mb-1">Admin Panel</p>
-          <h1 className="font-display text-3xl font-bold text-gray-900">Dashboard</h1>
-        </motion.div>
-      </div>
-    </div>
+interface RecentRow { id: string; guest: string; hotel: string; checkIn: string; status: string; }
 
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
-      {/* Stats */}
-      <motion.div variants={stagger} initial="hidden" animate="visible" className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-        {STATS.map(({ label, value, change, icon: Icon, bg, color, grad }) => (
-          <motion.div key={label} variants={fadeUp} whileHover={{ y: -3 }} transition={{ type: 'spring', stiffness: 300 }}
-            className="bg-white rounded-2xl border border-gray-100 p-5 hover:shadow-md transition-shadow">
-            <div className="flex items-start justify-between mb-4">
-              <div className={`p-2.5 rounded-xl ${bg}`}>
-                <Icon className={`h-5 w-5 ${color}`} />
-              </div>
-              <span className={`text-xs font-medium bg-gradient-to-r ${grad} bg-clip-text text-transparent`}>
-                <TrendingUp className="h-3 w-3 inline mr-0.5" />{change.split(' ')[0]}
-              </span>
-            </div>
-            <div className="text-2xl font-display font-bold text-gray-900">{value}</div>
-            <div className="text-gray-500 text-sm mt-1">{label}</div>
+const AdminDashboardPage: React.FC = () => {
+  const [counts, setCounts] = useState<{ hotels: number | null; rooms: number | null; reservations: number | null; users: number | null }>(
+    { hotels: null, rooms: null, reservations: null, users: null }
+  );
+  const [recent, setRecent] = useState<RecentRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      // Fetch independently so one failing endpoint doesn't blank the whole board.
+      const [hotels, rooms, reservations, users] = await Promise.all([
+        hotelService.getAllHotels().catch(() => null),
+        roomService.getAllRooms().catch(() => null),
+        reservationService.getAllReservations().catch(() => null),
+        userService.getAllUsers().catch(() => null),
+      ]) as any[];
+      if (!active) return;
+      setCounts({
+        hotels: hotels?.Count ?? null,
+        rooms: rooms?.Count ?? null,
+        reservations: reservations?.Count ?? null,
+        users: users?.Count ?? null,
+      });
+      const list = reservations?.Reservations ?? [];
+      setRecent(list.slice(0, 5).map((r: any): RecentRow => ({
+        id: r.bookingReference ?? `#${String(r.id).slice(0, 8)}`,
+        guest: r.User ? `${r.User.firstName ?? ''} ${r.User.lastName ?? ''}`.trim() : (r.guestName || 'Guest'),
+        hotel: r.Hotel?.name ?? '—',
+        checkIn: r.dateIn ? String(r.dateIn).slice(0, 10) : '—',
+        status: r.status ?? 'pending',
+      })));
+      setLoading(false);
+    })();
+    return () => { active = false; };
+  }, []);
+
+  const fmt = (n: number | null) => (n == null ? '—' : n.toLocaleString());
+
+  const STATS = [
+    { label: 'Total Hotels', value: fmt(counts.hotels), icon: Building2, color: 'text-blue-600', bg: 'bg-blue-50' },
+    { label: 'Total Rooms', value: fmt(counts.rooms), icon: BedDouble, color: 'text-violet-600', bg: 'bg-violet-50' },
+    { label: 'Reservations', value: fmt(counts.reservations), icon: CalendarCheck, color: 'text-emerald-600', bg: 'bg-emerald-50' },
+    { label: 'Registered Users', value: fmt(counts.users), icon: Users, color: 'text-accent-600', bg: 'bg-accent-50' },
+  ];
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="bg-white border-b border-gray-100">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <motion.div initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }}>
+            <p className="text-sm text-primary-600 font-semibold mb-1">Admin Panel</p>
+            <h1 className="font-display text-3xl font-bold text-gray-900">Dashboard</h1>
           </motion.div>
-        ))}
-      </motion.div>
+        </div>
+      </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-        {/* Recent reservations */}
-        <div className="lg:col-span-2">
-          <div className="bg-white rounded-2xl border border-gray-100">
-            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-50">
-              <h2 className="font-display font-semibold text-gray-900">Recent Reservations</h2>
-              <Link to="/admin/reservations" className="text-xs text-primary-600 hover:text-primary-700 font-semibold flex items-center gap-1 transition-colors">
-                View all <ArrowRight className="h-3.5 w-3.5" />
-              </Link>
-            </div>
-            <div className="divide-y divide-gray-50">
-              {RECENT.map((r) => {
-                const StatusIcon = statusIcon[r.status];
-                return (
-                  <motion.div key={r.id} initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="flex items-center justify-between px-6 py-4 hover:bg-gray-50 transition-colors">
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 mb-0.5">
-                        <span className="font-medium text-sm text-gray-900">{r.guest}</span>
-                        <span className="text-xs text-gray-400">#{r.id}</span>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+        <motion.div variants={stagger} initial="hidden" animate="visible" className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+          {STATS.map(({ label, value, icon: Icon, bg, color }) => (
+            <motion.div key={label} variants={fadeUp} whileHover={{ y: -3 }} transition={{ type: 'spring', stiffness: 300 }}
+              className="bg-white rounded-2xl border border-gray-100 p-5 hover:shadow-md transition-shadow">
+              <div className="flex items-start justify-between mb-4">
+                <div className={`p-2.5 rounded-xl ${bg}`}>
+                  <Icon className={`h-5 w-5 ${color}`} />
+                </div>
+              </div>
+              <div className="text-2xl font-display font-bold text-gray-900">{value}</div>
+              <div className="text-gray-500 text-sm mt-1">{label}</div>
+            </motion.div>
+          ))}
+        </motion.div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <div className="lg:col-span-2">
+            <div className="bg-white rounded-2xl border border-gray-100">
+              <div className="flex items-center justify-between px-6 py-4 border-b border-gray-50">
+                <h2 className="font-display font-semibold text-gray-900">Recent Reservations</h2>
+                <Link to="/admin/reservations" className="text-xs text-primary-600 hover:text-primary-700 font-semibold flex items-center gap-1 transition-colors">
+                  View all <ArrowRight className="h-3.5 w-3.5" />
+                </Link>
+              </div>
+              <div className="divide-y divide-gray-50">
+                {loading && (
+                  <div className="flex items-center justify-center py-12 text-gray-400"><Loader2 className="h-6 w-6 animate-spin" /></div>
+                )}
+                {!loading && recent.length === 0 && (
+                  <div className="text-center py-12 text-gray-400 text-sm">No reservations yet</div>
+                )}
+                {recent.map((r) => {
+                  const StatusIcon = statusIcon[r.status] ?? Clock;
+                  return (
+                    <motion.div key={r.id} initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="flex items-center justify-between px-6 py-4 hover:bg-gray-50 transition-colors">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-0.5">
+                          <span className="font-medium text-sm text-gray-900">{r.guest}</span>
+                          <span className="text-xs text-gray-400">{r.id}</span>
+                        </div>
+                        <p className="text-xs text-gray-400 truncate">{r.hotel} · {r.checkIn}</p>
                       </div>
-                      <p className="text-xs text-gray-400 truncate">{r.hotel} · {r.checkIn}</p>
-                    </div>
-                    <span className={`badge text-xs flex items-center gap-1 ml-4 ${statusStyle[r.status]}`}>
-                      <StatusIcon className="h-3 w-3" />
-                      {r.status.charAt(0).toUpperCase() + r.status.slice(1)}
-                    </span>
-                  </motion.div>
-                );
-              })}
+                      <span className={`badge text-xs flex items-center gap-1 ml-4 ${statusStyle[r.status] ?? 'bg-gray-100 text-gray-600'}`}>
+                        <StatusIcon className="h-3 w-3" />
+                        {r.status.charAt(0).toUpperCase() + r.status.slice(1)}
+                      </span>
+                    </motion.div>
+                  );
+                })}
+              </div>
             </div>
           </div>
-        </div>
 
-        {/* Quick links */}
-        <div>
-          <div className="bg-white rounded-2xl border border-gray-100">
-            <div className="px-6 py-4 border-b border-gray-50">
-              <h2 className="font-display font-semibold text-gray-900">Quick Actions</h2>
-            </div>
-            <div className="p-4 space-y-3">
-              {QUICK_LINKS.map(({ to, label, icon: Icon, desc, grad }) => (
-                <Link key={to} to={to}>
-                  <motion.div whileHover={{ x: 3 }} transition={{ type: 'spring', stiffness: 400 }}
-                    className="flex items-center gap-4 p-3 rounded-xl hover:bg-gray-50 transition-colors cursor-pointer">
-                    <div className={`p-2.5 rounded-xl bg-gradient-to-br ${grad} flex-shrink-0`}>
-                      <Icon className="h-4 w-4 text-white" />
-                    </div>
-                    <div className="min-w-0">
-                      <p className="text-sm font-semibold text-gray-800">{label}</p>
-                      <p className="text-xs text-gray-400 truncate">{desc}</p>
-                    </div>
-                    <ArrowRight className="h-4 w-4 text-gray-300 ml-auto flex-shrink-0" />
-                  </motion.div>
-                </Link>
-              ))}
+          <div>
+            <div className="bg-white rounded-2xl border border-gray-100">
+              <div className="px-6 py-4 border-b border-gray-50">
+                <h2 className="font-display font-semibold text-gray-900">Quick Actions</h2>
+              </div>
+              <div className="p-4 space-y-3">
+                {QUICK_LINKS.map(({ to, label, icon: Icon, desc, grad }) => (
+                  <Link key={to} to={to}>
+                    <motion.div whileHover={{ x: 3 }} transition={{ type: 'spring', stiffness: 400 }}
+                      className="flex items-center gap-4 p-3 rounded-xl hover:bg-gray-50 transition-colors cursor-pointer">
+                      <div className={`p-2.5 rounded-xl bg-gradient-to-br ${grad} flex-shrink-0`}>
+                        <Icon className="h-4 w-4 text-white" />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-sm font-semibold text-gray-800">{label}</p>
+                        <p className="text-xs text-gray-400 truncate">{desc}</p>
+                      </div>
+                      <ArrowRight className="h-4 w-4 text-gray-300 ml-auto flex-shrink-0" />
+                    </motion.div>
+                  </Link>
+                ))}
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default AdminDashboardPage;

--- a/CLIENT/src/pages/admin/ManageHotelsPage.tsx
+++ b/CLIENT/src/pages/admin/ManageHotelsPage.tsx
@@ -1,50 +1,119 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Plus, Search, Edit2, Trash2, X, MapPin, Star } from 'lucide-react';
+import { Plus, Search, Edit2, Trash2, X, MapPin, Star, Loader2 } from 'lucide-react';
 import toast from 'react-hot-toast';
+import { hotelService } from '../../services';
 
-const HOTELS = [
-  { id: '1', name: 'Eko Hotel & Suites', city: 'Lagos', category: 'Luxury', rooms: 24, rating: 4.8, status: 'active', grad: 'from-indigo-500 to-purple-700' },
-  { id: '2', name: 'Transcorp Hilton Abuja', city: 'Abuja', category: 'Luxury', rooms: 32, rating: 4.9, status: 'active', grad: 'from-cyan-500 to-blue-700' },
-  { id: '3', name: 'Hotel Presidential', city: 'Port Harcourt', category: 'Standard', rooms: 18, rating: 4.6, status: 'active', grad: 'from-emerald-500 to-teal-700' },
-  { id: '4', name: 'Hamdala Hotel', city: 'Kano', category: 'Budget', rooms: 12, rating: 4.4, status: 'inactive', grad: 'from-amber-500 to-orange-700' },
-  { id: '5', name: 'Wheatbaker Hotel', city: 'Lagos', category: 'Boutique', rooms: 15, rating: 4.7, status: 'active', grad: 'from-rose-500 to-pink-700' },
+interface HotelRow {
+  id: string;
+  name: string;
+  city: string;
+  category: string;
+  rooms: number;
+  rating: number;
+  contactEmail: string;
+  address: string;
+}
+
+interface HotelForm { name: string; city: string; category: string; contactEmail: string; address: string; }
+
+// Hotel types accepted by the backend (models/hotel hotelType).
+const CATEGORIES = ['budget', 'mid-range', 'luxury', 'resort', 'boutique'];
+const GRADS = [
+  'from-indigo-500 to-purple-700', 'from-cyan-500 to-blue-700', 'from-emerald-500 to-teal-700',
+  'from-amber-500 to-orange-700', 'from-rose-500 to-pink-700', 'from-violet-500 to-fuchsia-700',
 ];
 
-interface HotelForm { name: string; city: string; category: string; }
+const emptyForm: HotelForm = { name: '', city: '', category: 'luxury', contactEmail: '', address: '' };
 
-const CATEGORIES = ['Luxury', 'Standard', 'Budget', 'Boutique'];
+const toRow = (h: any): HotelRow => {
+  const reviews = h.ratingAndReview ?? [];
+  const rating = reviews.length
+    ? reviews.reduce((s: number, r: any) => s + (r.overallRating ?? 0), 0) / reviews.length
+    : 0;
+  return {
+    id: h.id,
+    name: h.name,
+    city: h.city ?? '—',
+    category: h.hotelType ?? '—',
+    rooms: Array.isArray(h.rooms) ? h.rooms.length : 0,
+    rating: Math.round(rating * 10) / 10,
+    contactEmail: h.contactEmail ?? '',
+    address: h.address ?? '',
+  };
+};
 
 const ManageHotelsPage: React.FC = () => {
-  const [hotels, setHotels] = useState(HOTELS);
+  const [hotels, setHotels] = useState<HotelRow[]>([]);
+  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [showModal, setShowModal] = useState(false);
-  const [editing, setEditing] = useState<typeof HOTELS[0] | null>(null);
-  const [form, setForm] = useState<HotelForm>({ name: '', city: '', category: 'Luxury' });
+  const [saving, setSaving] = useState(false);
+  const [editing, setEditing] = useState<HotelRow | null>(null);
+  const [form, setForm] = useState<HotelForm>(emptyForm);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res: any = await hotelService.getAllHotels();
+      const list = res?.Hotels ?? res?.hotels ?? res?.data ?? [];
+      setHotels(list.map(toRow));
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message ?? 'Failed to load hotels.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
 
   const filtered = hotels.filter((h) =>
     h.name.toLowerCase().includes(search.toLowerCase()) || h.city.toLowerCase().includes(search.toLowerCase())
   );
 
-  const openNew = () => { setEditing(null); setForm({ name: '', city: '', category: 'Luxury' }); setShowModal(true); };
-  const openEdit = (h: typeof HOTELS[0]) => { setEditing(h); setForm({ name: h.name, city: h.city, category: h.category }); setShowModal(true); };
-
-  const handleSave = () => {
-    if (!form.name.trim() || !form.city.trim()) { toast.error('Name and city are required.'); return; }
-    if (editing) {
-      setHotels((p) => p.map((h) => h.id === editing.id ? { ...h, ...form } : h));
-      toast.success('Hotel updated!');
-    } else {
-      const newHotel = { id: String(Date.now()), ...form, rooms: 0, rating: 0, status: 'active' as const, grad: 'from-gray-400 to-gray-600' };
-      setHotels((p) => [newHotel, ...p]);
-      toast.success('Hotel added!');
-    }
-    setShowModal(false);
+  const openNew = () => { setEditing(null); setForm(emptyForm); setShowModal(true); };
+  const openEdit = (h: HotelRow) => {
+    setEditing(h);
+    setForm({ name: h.name, city: h.city, category: h.category, contactEmail: h.contactEmail, address: h.address });
+    setShowModal(true);
   };
 
-  const handleDelete = (id: string) => {
-    setHotels((p) => p.filter((h) => h.id !== id));
-    toast.success('Hotel removed.');
+  const handleSave = async () => {
+    if (!form.name.trim() || !form.city.trim()) { toast.error('Name and city are required.'); return; }
+    if (!editing && !form.contactEmail.trim()) { toast.error('Contact email is required.'); return; }
+    setSaving(true);
+    try {
+      const payload = {
+        name: form.name,
+        city: form.city,
+        hotelType: form.category,
+        contactEmail: form.contactEmail || undefined,
+        address: form.address || undefined,
+      };
+      if (editing) {
+        await hotelService.updateHotel(editing.id, payload);
+        toast.success('Hotel updated!');
+      } else {
+        await hotelService.createHotel(payload);
+        toast.success('Hotel added!');
+      }
+      setShowModal(false);
+      await load();
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message ?? 'Failed to save hotel.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await hotelService.deleteHotel(id);
+      setHotels((p) => p.filter((h) => h.id !== id));
+      toast.success('Hotel removed.');
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message ?? 'Failed to remove hotel.');
+    }
   };
 
   return (
@@ -74,32 +143,27 @@ const ManageHotelsPage: React.FC = () => {
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-gray-100">
-                  {['Hotel', 'City', 'Category', 'Rooms', 'Rating', 'Status', 'Actions'].map((h) => (
+                  {['Hotel', 'City', 'Category', 'Rooms', 'Rating', 'Actions'].map((h) => (
                     <th key={h} className="text-left px-5 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wider whitespace-nowrap">{h}</th>
                   ))}
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-50">
-                {filtered.map((hotel) => (
+                {filtered.map((hotel, i) => (
                   <motion.tr key={hotel.id} initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="hover:bg-gray-50 transition-colors">
                     <td className="px-5 py-4">
                       <div className="flex items-center gap-3">
-                        <div className={`w-8 h-8 rounded-lg bg-gradient-to-br ${hotel.grad} flex-shrink-0`} />
+                        <div className={`w-8 h-8 rounded-lg bg-gradient-to-br ${GRADS[i % GRADS.length]} flex-shrink-0`} />
                         <span className="font-medium text-gray-900 whitespace-nowrap">{hotel.name}</span>
                       </div>
                     </td>
                     <td className="px-5 py-4 text-gray-500">
                       <span className="flex items-center gap-1"><MapPin className="h-3 w-3" />{hotel.city}</span>
                     </td>
-                    <td className="px-5 py-4"><span className="badge badge-primary text-xs">{hotel.category}</span></td>
+                    <td className="px-5 py-4"><span className="badge badge-primary text-xs capitalize">{hotel.category}</span></td>
                     <td className="px-5 py-4 text-gray-700">{hotel.rooms}</td>
                     <td className="px-5 py-4">
-                      <span className="flex items-center gap-1 text-amber-600 font-medium"><Star className="h-3.5 w-3.5 fill-amber-400" />{hotel.rating}</span>
-                    </td>
-                    <td className="px-5 py-4">
-                      <span className={`badge text-xs ${hotel.status === 'active' ? 'bg-emerald-100 text-emerald-700' : 'bg-gray-100 text-gray-500'}`}>
-                        {hotel.status}
-                      </span>
+                      <span className="flex items-center gap-1 text-amber-600 font-medium"><Star className="h-3.5 w-3.5 fill-amber-400" />{hotel.rating || '—'}</span>
                     </td>
                     <td className="px-5 py-4">
                       <div className="flex items-center gap-2">
@@ -115,7 +179,10 @@ const ManageHotelsPage: React.FC = () => {
                 ))}
               </tbody>
             </table>
-            {filtered.length === 0 && (
+            {loading && (
+              <div className="flex items-center justify-center py-16 text-gray-400"><Loader2 className="h-6 w-6 animate-spin" /></div>
+            )}
+            {!loading && filtered.length === 0 && (
               <div className="text-center py-16 text-gray-400 text-sm">No hotels found</div>
             )}
           </div>
@@ -140,20 +207,30 @@ const ManageHotelsPage: React.FC = () => {
                   <input type="text" placeholder="e.g. Eko Hotel & Suites" value={form.name} onChange={(e) => setForm((p) => ({ ...p, name: e.target.value }))} className="input-field" />
                 </div>
                 <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1.5">Contact Email</label>
+                  <input type="email" placeholder="reservations@hotel.com" value={form.contactEmail} onChange={(e) => setForm((p) => ({ ...p, contactEmail: e.target.value }))} className="input-field" />
+                </div>
+                <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1.5">City</label>
                   <input type="text" placeholder="e.g. Lagos" value={form.city} onChange={(e) => setForm((p) => ({ ...p, city: e.target.value }))} className="input-field" />
                 </div>
                 <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1.5">Address (optional)</label>
+                  <input type="text" placeholder="Street, area" value={form.address} onChange={(e) => setForm((p) => ({ ...p, address: e.target.value }))} className="input-field" />
+                </div>
+                <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1.5">Category</label>
-                  <select value={form.category} onChange={(e) => setForm((p) => ({ ...p, category: e.target.value }))} className="input-field">
-                    {CATEGORIES.map((c) => <option key={c}>{c}</option>)}
+                  <select value={form.category} onChange={(e) => setForm((p) => ({ ...p, category: e.target.value }))} className="input-field capitalize">
+                    {CATEGORIES.map((c) => <option key={c} value={c}>{c}</option>)}
                   </select>
                 </div>
               </div>
 
               <div className="flex gap-3 mt-6">
                 <button onClick={() => setShowModal(false)} className="btn-secondary flex-1">Cancel</button>
-                <button onClick={handleSave} className="btn-accent flex-1">{editing ? 'Save Changes' : 'Add Hotel'}</button>
+                <button onClick={handleSave} disabled={saving} className="btn-accent flex-1 disabled:opacity-60">
+                  {saving ? 'Saving…' : editing ? 'Save Changes' : 'Add Hotel'}
+                </button>
               </div>
             </motion.div>
           </motion.div>

--- a/CLIENT/src/pages/admin/ManageReservationsPage.tsx
+++ b/CLIENT/src/pages/admin/ManageReservationsPage.tsx
@@ -1,33 +1,93 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { motion } from 'framer-motion';
-import { Search, CheckCircle, X, Clock, ChevronDown } from 'lucide-react';
+import { Search, LogIn, LogOut, Trash2, Loader2, ChevronDown } from 'lucide-react';
 import toast from 'react-hot-toast';
+import { reservationService } from '../../services';
 
-const RESERVATIONS = [
-  { id: 'R092', guest: 'Amaka Nwosu', email: 'amaka@email.com', hotel: 'Eko Hotel & Suites', room: 'Deluxe Suite', checkIn: '2026-04-10', checkOut: '2026-04-13', total: 243000, status: 'confirmed' },
-  { id: 'R091', guest: 'Tunde Adeyemi', email: 'tunde@email.com', hotel: 'Transcorp Hilton', room: 'Executive Suite', checkIn: '2026-04-08', checkOut: '2026-04-10', total: 220000, status: 'pending' },
-  { id: 'R090', guest: 'Chioma Okafor', email: 'chioma@email.com', hotel: 'Hotel Presidential', room: 'Standard Room', checkIn: '2026-04-06', checkOut: '2026-04-08', total: 86900, status: 'completed' },
-  { id: 'R089', guest: 'Emeka Eze', email: 'emeka@email.com', hotel: 'Nicon Luxury Hotel', room: 'Deluxe Suite', checkIn: '2026-04-05', checkOut: '2026-04-06', total: 45100, status: 'cancelled' },
-  { id: 'R088', guest: 'Fatima Bello', email: 'fatima@email.com', hotel: 'Wheatbaker Hotel', room: 'Deluxe Room', checkIn: '2026-04-03', checkOut: '2026-04-05', total: 107800, status: 'confirmed' },
-];
+interface ReservationRow {
+  id: string;
+  ref: string;
+  guest: string;
+  email: string;
+  hotel: string;
+  room: string;
+  checkIn: string;
+  checkOut: string;
+  total: number;
+  status: string;
+}
 
-const STATUS_TABS = ['All', 'Confirmed', 'Pending', 'Completed', 'Cancelled'];
-const statusStyle: Record<string, string> = { confirmed: 'bg-emerald-100 text-emerald-700', pending: 'bg-amber-100 text-amber-700', completed: 'bg-blue-100 text-blue-700', cancelled: 'bg-red-100 text-red-600' };
+const STATUS_TABS = ['All', 'Pending', 'Confirmed', 'Checked-in', 'Checked-out', 'Cancelled'];
+const statusStyle: Record<string, string> = {
+  confirmed: 'bg-emerald-100 text-emerald-700',
+  pending: 'bg-amber-100 text-amber-700',
+  'checked-in': 'bg-blue-100 text-blue-700',
+  'checked-out': 'bg-gray-100 text-gray-600',
+  cancelled: 'bg-red-100 text-red-600',
+  'no-show': 'bg-red-100 text-red-600',
+};
+
+const dateOnly = (d?: string) => (d ? String(d).slice(0, 10) : '—');
+
+const toRow = (r: any): ReservationRow => {
+  const nights = r.dateIn && r.dateOut
+    ? Math.max(1, Math.round((new Date(r.dateOut).getTime() - new Date(r.dateIn).getTime()) / 86400000))
+    : 1;
+  const price = r.Room?.price ?? 0;
+  const guestName = r.User ? `${r.User.firstName ?? ''} ${r.User.lastName ?? ''}`.trim() : r.guestName;
+  return {
+    id: r.id,
+    ref: r.bookingReference ?? `#${String(r.id).slice(0, 8)}`,
+    guest: guestName || 'Guest',
+    email: r.User?.email ?? r.guestEmail ?? '—',
+    hotel: r.Hotel?.name ?? '—',
+    room: r.Room?.category ?? r.Room?.type ?? '—',
+    checkIn: dateOnly(r.dateIn),
+    checkOut: dateOnly(r.dateOut),
+    total: price * nights,
+    status: r.status ?? 'pending',
+  };
+};
 
 const ManageReservationsPage: React.FC = () => {
-  const [reservations, setReservations] = useState(RESERVATIONS);
+  const [reservations, setReservations] = useState<ReservationRow[]>([]);
+  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [tab, setTab] = useState('All');
 
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res: any = await reservationService.getAllReservations();
+      const list = res?.Reservations ?? res?.reservations ?? res?.data ?? [];
+      setReservations(list.map(toRow));
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message ?? 'Failed to load reservations.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
   const filtered = reservations.filter((r) => {
     const matchTab = tab === 'All' || r.status === tab.toLowerCase();
-    const matchSearch = r.guest.toLowerCase().includes(search.toLowerCase()) || r.hotel.toLowerCase().includes(search.toLowerCase()) || r.id.toLowerCase().includes(search.toLowerCase());
+    const q = search.toLowerCase();
+    const matchSearch = r.guest.toLowerCase().includes(q) || r.hotel.toLowerCase().includes(q) || r.ref.toLowerCase().includes(q);
     return matchTab && matchSearch;
   });
 
-  const updateStatus = (id: string, status: string) => {
-    setReservations((p) => p.map((r) => r.id === id ? { ...r, status } : r));
-    toast.success(`Reservation ${status}`);
+  const doCheckIn = async (id: string) => {
+    try { await reservationService.checkIn(id); toast.success('Guest checked in'); await load(); }
+    catch (err: any) { toast.error(err?.response?.data?.message ?? 'Check-in failed'); }
+  };
+  const doCheckOut = async (id: string) => {
+    try { await reservationService.checkOut(id); toast.success('Guest checked out'); await load(); }
+    catch (err: any) { toast.error(err?.response?.data?.message ?? 'Check-out failed'); }
+  };
+  const doDelete = async (id: string) => {
+    try { await reservationService.deleteReservation(id); setReservations((p) => p.filter((r) => r.id !== id)); toast.success('Reservation deleted'); }
+    catch (err: any) { toast.error(err?.response?.data?.message ?? 'Delete failed'); }
   };
 
   return (
@@ -40,7 +100,7 @@ const ManageReservationsPage: React.FC = () => {
           <div className="flex flex-col sm:flex-row sm:items-center gap-4">
             <div className="relative max-w-xs">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
-              <input type="text" placeholder="Search guest, hotel or ID…" value={search} onChange={(e) => setSearch(e.target.value)} className="input-field pl-9 text-sm py-2" />
+              <input type="text" placeholder="Search guest, hotel or ref…" value={search} onChange={(e) => setSearch(e.target.value)} className="input-field pl-9 text-sm py-2" />
             </div>
             <div className="flex gap-2 overflow-x-auto pb-1">
               {STATUS_TABS.map((t) => (
@@ -60,7 +120,7 @@ const ManageReservationsPage: React.FC = () => {
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-gray-100">
-                  {['ID', 'Guest', 'Hotel / Room', 'Dates', 'Total', 'Status', 'Actions'].map((h) => (
+                  {['Ref', 'Guest', 'Hotel / Room', 'Dates', 'Total', 'Status', 'Actions'].map((h) => (
                     <th key={h} className="text-left px-5 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wider whitespace-nowrap">{h}</th>
                   ))}
                 </tr>
@@ -68,7 +128,7 @@ const ManageReservationsPage: React.FC = () => {
               <tbody className="divide-y divide-gray-50">
                 {filtered.map((r) => (
                   <motion.tr key={r.id} initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="hover:bg-gray-50 transition-colors">
-                    <td className="px-5 py-4 font-medium text-gray-500">#{r.id}</td>
+                    <td className="px-5 py-4 font-medium text-gray-500 whitespace-nowrap">{r.ref}</td>
                     <td className="px-5 py-4">
                       <div className="font-medium text-gray-900 whitespace-nowrap">{r.guest}</div>
                       <div className="text-xs text-gray-400">{r.email}</div>
@@ -81,25 +141,29 @@ const ManageReservationsPage: React.FC = () => {
                       <div>{r.checkIn}</div>
                       <div className="text-xs">→ {r.checkOut}</div>
                     </td>
-                    <td className="px-5 py-4 font-semibold text-primary-700 whitespace-nowrap">₦{r.total.toLocaleString()}</td>
+                    <td className="px-5 py-4 font-semibold text-primary-700 whitespace-nowrap">{r.total ? `₦${r.total.toLocaleString()}` : '—'}</td>
                     <td className="px-5 py-4">
-                      <span className={`badge text-xs ${statusStyle[r.status]}`}>{r.status.charAt(0).toUpperCase() + r.status.slice(1)}</span>
+                      <span className={`badge text-xs ${statusStyle[r.status] ?? 'bg-gray-100 text-gray-600'}`}>{r.status.charAt(0).toUpperCase() + r.status.slice(1)}</span>
                     </td>
                     <td className="px-5 py-4">
                       <div className="relative group">
                         <button className="flex items-center gap-1 text-xs font-medium text-gray-600 hover:text-primary-600 bg-gray-100 hover:bg-primary-50 px-3 py-1.5 rounded-lg transition-all">
-                          Update <ChevronDown className="h-3 w-3" />
+                          Actions <ChevronDown className="h-3 w-3" />
                         </button>
                         <div className="absolute right-0 top-full mt-1 w-36 bg-white rounded-xl shadow-xl border border-gray-100 py-1.5 hidden group-hover:block z-10">
-                          {['confirmed', 'completed', 'cancelled'].filter((s) => s !== r.status).map((s) => (
-                            <button key={s} onClick={() => updateStatus(r.id, s)}
-                              className="w-full text-left px-4 py-2 text-xs hover:bg-gray-50 flex items-center gap-2 transition-colors capitalize">
-                              {s === 'confirmed' && <CheckCircle className="h-3.5 w-3.5 text-emerald-500" />}
-                              {s === 'completed' && <Clock className="h-3.5 w-3.5 text-blue-500" />}
-                              {s === 'cancelled' && <X className="h-3.5 w-3.5 text-red-500" />}
-                              {s}
+                          {r.status !== 'checked-in' && r.status !== 'checked-out' && r.status !== 'cancelled' && (
+                            <button onClick={() => doCheckIn(r.id)} className="w-full text-left px-4 py-2 text-xs hover:bg-gray-50 flex items-center gap-2 transition-colors">
+                              <LogIn className="h-3.5 w-3.5 text-blue-500" /> Check in
                             </button>
-                          ))}
+                          )}
+                          {r.status === 'checked-in' && (
+                            <button onClick={() => doCheckOut(r.id)} className="w-full text-left px-4 py-2 text-xs hover:bg-gray-50 flex items-center gap-2 transition-colors">
+                              <LogOut className="h-3.5 w-3.5 text-gray-500" /> Check out
+                            </button>
+                          )}
+                          <button onClick={() => doDelete(r.id)} className="w-full text-left px-4 py-2 text-xs hover:bg-red-50 text-red-600 flex items-center gap-2 transition-colors">
+                            <Trash2 className="h-3.5 w-3.5" /> Delete
+                          </button>
                         </div>
                       </div>
                     </td>
@@ -107,7 +171,8 @@ const ManageReservationsPage: React.FC = () => {
                 ))}
               </tbody>
             </table>
-            {filtered.length === 0 && <div className="text-center py-16 text-gray-400 text-sm">No reservations found</div>}
+            {loading && <div className="flex items-center justify-center py-16 text-gray-400"><Loader2 className="h-6 w-6 animate-spin" /></div>}
+            {!loading && filtered.length === 0 && <div className="text-center py-16 text-gray-400 text-sm">No reservations found</div>}
           </div>
         </div>
       </div>

--- a/CLIENT/src/pages/admin/ManageRoomsPage.tsx
+++ b/CLIENT/src/pages/admin/ManageRoomsPage.tsx
@@ -1,47 +1,107 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Plus, Search, Edit2, Trash2, X, BedDouble, Users } from 'lucide-react';
+import { Plus, Search, Edit2, Trash2, X, BedDouble, Users, Loader2 } from 'lucide-react';
 import toast from 'react-hot-toast';
+import { roomService, hotelService } from '../../services';
 
-const ROOMS = [
-  { id: 'r1', hotel: 'Eko Hotel & Suites', category: 'Standard Room', capacity: 2, price: 45000, status: 'available', grad: 'from-slate-400 to-slate-600' },
-  { id: 'r2', hotel: 'Eko Hotel & Suites', category: 'Deluxe Suite', capacity: 2, price: 75000, status: 'occupied', grad: 'from-blue-400 to-indigo-600' },
-  { id: 'r3', hotel: 'Transcorp Hilton', category: 'Executive Suite', capacity: 3, price: 110000, status: 'available', grad: 'from-violet-400 to-purple-600' },
-  { id: 'r4', hotel: 'Hotel Presidential', category: 'Standard Room', capacity: 2, price: 35000, status: 'maintenance', grad: 'from-amber-400 to-orange-600' },
-  { id: 'r5', hotel: 'Wheatbaker Hotel', category: 'Deluxe Room', capacity: 2, price: 48000, status: 'available', grad: 'from-rose-400 to-pink-600' },
-];
+interface RoomRow {
+  id: string;
+  hotel: string;
+  category: string;
+  capacity: number;
+  price: number;
+  condition: string;
+}
 
-const statusStyle: Record<string, string> = { available: 'bg-emerald-100 text-emerald-700', occupied: 'bg-blue-100 text-blue-700', maintenance: 'bg-amber-100 text-amber-700' };
+// Room categories accepted by the backend (models/room category ENUM).
+const CATEGORIES = ['regular', 'luxury', 'conference', 'event hall', 'studio apartment'];
+const GRADS = ['from-slate-400 to-slate-600', 'from-blue-400 to-indigo-600', 'from-violet-400 to-purple-600', 'from-amber-400 to-orange-600', 'from-rose-400 to-pink-600'];
 
-interface RoomForm { hotel: string; category: string; capacity: string; price: string; }
+interface RoomForm { contactEmail: string; category: string; capacity: string; price: string; }
+const emptyForm: RoomForm = { contactEmail: '', category: 'regular', capacity: '2', price: '' };
 
 const ManageRoomsPage: React.FC = () => {
-  const [rooms, setRooms] = useState(ROOMS);
+  const [rooms, setRooms] = useState<RoomRow[]>([]);
+  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [showModal, setShowModal] = useState(false);
-  const [editing, setEditing] = useState<typeof ROOMS[0] | null>(null);
-  const [form, setForm] = useState<RoomForm>({ hotel: '', category: 'Standard Room', capacity: '2', price: '' });
+  const [saving, setSaving] = useState(false);
+  const [editing, setEditing] = useState<RoomRow | null>(null);
+  const [form, setForm] = useState<RoomForm>(emptyForm);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [roomsRes, hotelsRes]: any[] = await Promise.all([
+        roomService.getAllRooms(),
+        hotelService.getAllHotels().catch(() => ({})),
+      ]);
+      const hotelList = hotelsRes?.Hotels ?? hotelsRes?.hotels ?? [];
+      const nameById = new Map<string, string>(hotelList.map((h: any) => [h.id, h.name]));
+      const list = roomsRes?.Rooms ?? roomsRes?.rooms ?? roomsRes?.data ?? [];
+      setRooms(list.map((r: any): RoomRow => ({
+        id: r.id,
+        hotel: nameById.get(r.hotelId) ?? '—',
+        category: r.category ?? '—',
+        capacity: r.capacity ?? 0,
+        price: r.price ?? 0,
+        condition: r.condition ?? '—',
+      })));
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message ?? 'Failed to load rooms.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
 
   const filtered = rooms.filter((r) =>
     r.hotel.toLowerCase().includes(search.toLowerCase()) || r.category.toLowerCase().includes(search.toLowerCase())
   );
 
-  const openNew = () => { setEditing(null); setForm({ hotel: '', category: 'Standard Room', capacity: '2', price: '' }); setShowModal(true); };
-  const openEdit = (r: typeof ROOMS[0]) => { setEditing(r); setForm({ hotel: r.hotel, category: r.category, capacity: String(r.capacity), price: String(r.price) }); setShowModal(true); };
+  const openNew = () => { setEditing(null); setForm(emptyForm); setShowModal(true); };
+  const openEdit = (r: RoomRow) => { setEditing(r); setForm({ contactEmail: '', category: r.category, capacity: String(r.capacity), price: String(r.price) }); setShowModal(true); };
 
-  const handleSave = () => {
-    if (!form.hotel.trim() || !form.price) { toast.error('Hotel and price are required.'); return; }
-    if (editing) {
-      setRooms((p) => p.map((r) => r.id === editing.id ? { ...r, hotel: form.hotel, category: form.category, capacity: Number(form.capacity), price: Number(form.price) } : r));
-      toast.success('Room updated!');
-    } else {
-      setRooms((p) => [{ id: String(Date.now()), hotel: form.hotel, category: form.category, capacity: Number(form.capacity), price: Number(form.price), status: 'available', grad: 'from-gray-400 to-gray-600' }, ...p]);
-      toast.success('Room added!');
+  const handleSave = async () => {
+    if (!form.price) { toast.error('Price is required.'); return; }
+    if (!editing && !form.contactEmail.trim()) { toast.error("The hotel's contact email is required to add a room."); return; }
+    setSaving(true);
+    try {
+      if (editing) {
+        await roomService.updateRoom(editing.id, {
+          category: form.category as any,
+          capacity: Number(form.capacity),
+          price: Number(form.price),
+        } as any);
+        toast.success('Room updated!');
+      } else {
+        await roomService.createRoom({
+          contactEmail: form.contactEmail,
+          category: form.category,
+          capacity: Number(form.capacity),
+          price: Number(form.price),
+        } as any);
+        toast.success('Room added!');
+      }
+      setShowModal(false);
+      await load();
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message ?? 'Failed to save room.');
+    } finally {
+      setSaving(false);
     }
-    setShowModal(false);
   };
 
-  const handleDelete = (id: string) => { setRooms((p) => p.filter((r) => r.id !== id)); toast.success('Room removed.'); };
+  const handleDelete = async (id: string) => {
+    try {
+      await roomService.deleteRoom(id);
+      setRooms((p) => p.filter((r) => r.id !== id));
+      toast.success('Room removed.');
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message ?? 'Failed to remove room.');
+    }
+  };
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -70,20 +130,20 @@ const ManageRoomsPage: React.FC = () => {
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-gray-100">
-                  {['Room', 'Hotel', 'Capacity', 'Price/Night', 'Status', 'Actions'].map((h) => (
+                  {['Room', 'Hotel', 'Capacity', 'Price/Night', 'Condition', 'Actions'].map((h) => (
                     <th key={h} className="text-left px-5 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wider whitespace-nowrap">{h}</th>
                   ))}
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-50">
-                {filtered.map((room) => (
+                {filtered.map((room, i) => (
                   <motion.tr key={room.id} initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="hover:bg-gray-50 transition-colors">
                     <td className="px-5 py-4">
                       <div className="flex items-center gap-3">
-                        <div className={`w-8 h-8 rounded-lg bg-gradient-to-br ${room.grad} flex-shrink-0`} />
+                        <div className={`w-8 h-8 rounded-lg bg-gradient-to-br ${GRADS[i % GRADS.length]} flex-shrink-0`} />
                         <div>
-                          <span className="font-medium text-gray-900 whitespace-nowrap block">{room.category}</span>
-                          <span className="text-xs text-gray-400 flex items-center gap-1"><BedDouble className="h-3 w-3" />Suite/Room</span>
+                          <span className="font-medium text-gray-900 whitespace-nowrap block capitalize">{room.category}</span>
+                          <span className="text-xs text-gray-400 flex items-center gap-1"><BedDouble className="h-3 w-3" />Room</span>
                         </div>
                       </div>
                     </td>
@@ -92,9 +152,7 @@ const ManageRoomsPage: React.FC = () => {
                       <span className="flex items-center gap-1"><Users className="h-3.5 w-3.5 text-gray-400" />{room.capacity}</span>
                     </td>
                     <td className="px-5 py-4 font-semibold text-primary-700">₦{room.price.toLocaleString()}</td>
-                    <td className="px-5 py-4">
-                      <span className={`badge text-xs ${statusStyle[room.status]}`}>{room.status}</span>
-                    </td>
+                    <td className="px-5 py-4"><span className="badge text-xs bg-gray-100 text-gray-600 capitalize">{room.condition}</span></td>
                     <td className="px-5 py-4">
                       <div className="flex items-center gap-2">
                         <button onClick={() => openEdit(room)} className="p-1.5 text-gray-400 hover:text-primary-600 hover:bg-primary-50 rounded-lg transition-all">
@@ -109,7 +167,8 @@ const ManageRoomsPage: React.FC = () => {
                 ))}
               </tbody>
             </table>
-            {filtered.length === 0 && <div className="text-center py-16 text-gray-400 text-sm">No rooms found</div>}
+            {loading && <div className="flex items-center justify-center py-16 text-gray-400"><Loader2 className="h-6 w-6 animate-spin" /></div>}
+            {!loading && filtered.length === 0 && <div className="text-center py-16 text-gray-400 text-sm">No rooms found</div>}
           </div>
         </div>
       </div>
@@ -125,14 +184,17 @@ const ManageRoomsPage: React.FC = () => {
                 </button>
               </div>
               <div className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1.5">Hotel</label>
-                  <input type="text" placeholder="Hotel name" value={form.hotel} onChange={(e) => setForm((p) => ({ ...p, hotel: e.target.value }))} className="input-field" />
-                </div>
+                {!editing && (
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1.5">Hotel contact email</label>
+                    <input type="email" placeholder="reservations@hotel.com" value={form.contactEmail} onChange={(e) => setForm((p) => ({ ...p, contactEmail: e.target.value }))} className="input-field" />
+                    <p className="text-xs text-gray-400 mt-1">The room is added to the hotel with this contact email.</p>
+                  </div>
+                )}
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1.5">Room Category</label>
-                  <select value={form.category} onChange={(e) => setForm((p) => ({ ...p, category: e.target.value }))} className="input-field">
-                    {['Standard Room', 'Deluxe Room', 'Deluxe Suite', 'Executive Suite', 'Presidential Suite'].map((c) => <option key={c}>{c}</option>)}
+                  <select value={form.category} onChange={(e) => setForm((p) => ({ ...p, category: e.target.value }))} className="input-field capitalize">
+                    {CATEGORIES.map((c) => <option key={c} value={c}>{c}</option>)}
                   </select>
                 </div>
                 <div className="grid grid-cols-2 gap-3">
@@ -150,7 +212,9 @@ const ManageRoomsPage: React.FC = () => {
               </div>
               <div className="flex gap-3 mt-6">
                 <button onClick={() => setShowModal(false)} className="btn-secondary flex-1">Cancel</button>
-                <button onClick={handleSave} className="btn-accent flex-1">{editing ? 'Save Changes' : 'Add Room'}</button>
+                <button onClick={handleSave} disabled={saving} className="btn-accent flex-1 disabled:opacity-60">
+                  {saving ? 'Saving…' : editing ? 'Save Changes' : 'Add Room'}
+                </button>
               </div>
             </motion.div>
           </motion.div>

--- a/CLIENT/src/pages/admin/ManageUsersPage.tsx
+++ b/CLIENT/src/pages/admin/ManageUsersPage.tsx
@@ -1,42 +1,94 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Search, Edit2, Trash2, X, UserCheck, UserX, Shield } from 'lucide-react';
+import { Search, Edit2, Trash2, X, Shield, Loader2 } from 'lucide-react';
 import toast from 'react-hot-toast';
+import { userService } from '../../services';
 
-const USERS = [
-  { id: 'u1', firstName: 'Amaka', lastName: 'Nwosu', email: 'amaka@email.com', phone: '08012345678', userType: 'guest', status: 'active', joined: '2026-01-15', bookings: 4 },
-  { id: 'u2', firstName: 'Tunde', lastName: 'Adeyemi', email: 'tunde@email.com', phone: '08023456789', userType: 'guest', status: 'active', joined: '2026-02-10', bookings: 7 },
-  { id: 'u3', firstName: 'Chioma', lastName: 'Okafor', email: 'chioma@email.com', phone: '07034567890', userType: 'admin', status: 'active', joined: '2025-11-05', bookings: 1 },
-  { id: 'u4', firstName: 'Emeka', lastName: 'Eze', email: 'emeka@email.com', phone: '09045678901', userType: 'guest', status: 'suspended', joined: '2026-03-01', bookings: 2 },
-  { id: 'u5', firstName: 'Fatima', lastName: 'Bello', email: 'fatima@email.com', phone: '08156789012', userType: 'guest', status: 'active', joined: '2026-03-18', bookings: 3 },
-];
+interface UserRow {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  userType: string;
+  joined: string;
+}
 
-const typeStyle: Record<string, string> = { admin: 'bg-violet-100 text-violet-700', guest: 'bg-gray-100 text-gray-600', org_admin: 'bg-blue-100 text-blue-700' };
-const statusStyle: Record<string, string> = { active: 'bg-emerald-100 text-emerald-700', suspended: 'bg-red-100 text-red-600' };
+const typeStyle: Record<string, string> = {
+  admin: 'bg-violet-100 text-violet-700',
+  org_admin: 'bg-blue-100 text-blue-700',
+  guest: 'bg-gray-100 text-gray-600',
+  regular: 'bg-gray-100 text-gray-600',
+  premium: 'bg-amber-100 text-amber-700',
+};
+
+interface EditForm { firstName: string; lastName: string; phone: string; }
 
 const ManageUsersPage: React.FC = () => {
-  const [users, setUsers] = useState(USERS);
+  const [users, setUsers] = useState<UserRow[]>([]);
+  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
-  const [editUser, setEditUser] = useState<typeof USERS[0] | null>(null);
+  const [editUser, setEditUser] = useState<UserRow | null>(null);
+  const [form, setForm] = useState<EditForm>({ firstName: '', lastName: '', phone: '' });
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res: any = await userService.getAllUsers();
+      const list = res?.Users ?? res?.users ?? res?.data ?? [];
+      setUsers(list.map((u: any): UserRow => ({
+        id: u.id,
+        firstName: u.firstName ?? '',
+        lastName: u.lastName ?? '',
+        email: u.email ?? '—',
+        phone: u.phoneNumber != null ? String(u.phoneNumber) : '—',
+        userType: u.type ?? u.userType ?? 'regular',
+        joined: u.createdAt ? String(u.createdAt).slice(0, 10) : '—',
+      })));
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message ?? 'Failed to load users.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
 
   const filtered = users.filter((u) =>
     `${u.firstName} ${u.lastName}`.toLowerCase().includes(search.toLowerCase()) ||
     u.email.toLowerCase().includes(search.toLowerCase())
   );
 
-  const toggleStatus = (id: string) => {
-    setUsers((p) => p.map((u) => u.id === id ? { ...u, status: u.status === 'active' ? 'suspended' : 'active' } : u));
-    const user = users.find((u) => u.id === id);
-    toast.success(`User ${user?.status === 'active' ? 'suspended' : 'activated'}`);
+  const openEdit = (u: UserRow) => { setEditUser(u); setForm({ firstName: u.firstName, lastName: u.lastName, phone: u.phone === '—' ? '' : u.phone }); };
+
+  const handleSave = async () => {
+    if (!editUser) return;
+    setSaving(true);
+    try {
+      await userService.updateUser(editUser.id, {
+        firstName: form.firstName,
+        lastName: form.lastName,
+        phoneNumber: form.phone,
+      } as any);
+      toast.success('User updated!');
+      setEditUser(null);
+      await load();
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message ?? 'Failed to update user.');
+    } finally {
+      setSaving(false);
+    }
   };
 
-  const handleDelete = (id: string) => { setUsers((p) => p.filter((u) => u.id !== id)); toast.success('User removed.'); };
-
-  const handleSaveRole = (role: string) => {
-    if (!editUser) return;
-    setUsers((p) => p.map((u) => u.id === editUser.id ? { ...u, userType: role } : u));
-    toast.success('Role updated!');
-    setEditUser(null);
+  const handleDelete = async (id: string) => {
+    try {
+      await userService.deleteUser(id);
+      setUsers((p) => p.filter((u) => u.id !== id));
+      toast.success('User removed.');
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message ?? 'Failed to remove user.');
+    }
   };
 
   return (
@@ -58,7 +110,7 @@ const ManageUsersPage: React.FC = () => {
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-gray-100">
-                  {['User', 'Email', 'Phone', 'Role', 'Bookings', 'Status', 'Joined', 'Actions'].map((h) => (
+                  {['User', 'Email', 'Phone', 'Role', 'Joined', 'Actions'].map((h) => (
                     <th key={h} className="text-left px-5 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wider whitespace-nowrap">{h}</th>
                   ))}
                 </tr>
@@ -69,7 +121,7 @@ const ManageUsersPage: React.FC = () => {
                     <td className="px-5 py-4">
                       <div className="flex items-center gap-3">
                         <div className="w-8 h-8 rounded-full bg-gradient-to-br from-primary-400 to-primary-600 flex items-center justify-center text-white text-xs font-bold flex-shrink-0">
-                          {user.firstName[0]}{user.lastName[0]}
+                          {(user.firstName[0] ?? '').toUpperCase()}{(user.lastName[0] ?? '').toUpperCase()}
                         </div>
                         <span className="font-medium text-gray-900 whitespace-nowrap">{user.firstName} {user.lastName}</span>
                       </div>
@@ -78,22 +130,15 @@ const ManageUsersPage: React.FC = () => {
                     <td className="px-5 py-4 text-gray-500 whitespace-nowrap">{user.phone}</td>
                     <td className="px-5 py-4">
                       <span className={`badge text-xs ${typeStyle[user.userType] ?? 'bg-gray-100 text-gray-600'}`}>
-                        {user.userType === 'admin' && <Shield className="h-3 w-3 inline mr-1" />}
+                        {(user.userType === 'admin' || user.userType === 'org_admin') && <Shield className="h-3 w-3 inline mr-1" />}
                         {user.userType}
                       </span>
-                    </td>
-                    <td className="px-5 py-4 text-gray-700 text-center">{user.bookings}</td>
-                    <td className="px-5 py-4">
-                      <span className={`badge text-xs ${statusStyle[user.status]}`}>{user.status}</span>
                     </td>
                     <td className="px-5 py-4 text-gray-400 text-xs whitespace-nowrap">{user.joined}</td>
                     <td className="px-5 py-4">
                       <div className="flex items-center gap-1.5">
-                        <button onClick={() => setEditUser(user)} title="Change role" className="p-1.5 text-gray-400 hover:text-violet-600 hover:bg-violet-50 rounded-lg transition-all">
+                        <button onClick={() => openEdit(user)} title="Edit" className="p-1.5 text-gray-400 hover:text-primary-600 hover:bg-primary-50 rounded-lg transition-all">
                           <Edit2 className="h-4 w-4" />
-                        </button>
-                        <button onClick={() => toggleStatus(user.id)} title={user.status === 'active' ? 'Suspend' : 'Activate'} className={`p-1.5 rounded-lg transition-all ${user.status === 'active' ? 'text-gray-400 hover:text-amber-600 hover:bg-amber-50' : 'text-gray-400 hover:text-emerald-600 hover:bg-emerald-50'}`}>
-                          {user.status === 'active' ? <UserX className="h-4 w-4" /> : <UserCheck className="h-4 w-4" />}
                         </button>
                         <button onClick={() => handleDelete(user.id)} className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all">
                           <Trash2 className="h-4 w-4" />
@@ -104,33 +149,42 @@ const ManageUsersPage: React.FC = () => {
                 ))}
               </tbody>
             </table>
-            {filtered.length === 0 && <div className="text-center py-16 text-gray-400 text-sm">No users found</div>}
+            {loading && <div className="flex items-center justify-center py-16 text-gray-400"><Loader2 className="h-6 w-6 animate-spin" /></div>}
+            {!loading && filtered.length === 0 && <div className="text-center py-16 text-gray-400 text-sm">No users found</div>}
           </div>
         </div>
       </div>
 
-      {/* Role edit modal */}
+      {/* Edit modal — role changes go through a controlled flow, not here. */}
       <AnimatePresence>
         {editUser && (
           <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
             <motion.div initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }} className="bg-white rounded-2xl shadow-2xl w-full max-w-sm p-6">
               <div className="flex items-center justify-between mb-6">
-                <h3 className="font-display font-bold text-gray-900">Change Role</h3>
+                <h3 className="font-display font-bold text-gray-900">Edit User</h3>
                 <button onClick={() => setEditUser(null)} className="p-2 text-gray-400 hover:text-gray-700 hover:bg-gray-100 rounded-xl transition-all">
                   <X className="h-5 w-5" />
                 </button>
               </div>
-              <p className="text-sm text-gray-500 mb-5">Changing role for <span className="font-semibold text-gray-900">{editUser.firstName} {editUser.lastName}</span></p>
-              <div className="space-y-2">
-                {['guest', 'admin', 'org_admin'].map((role) => (
-                  <button key={role} onClick={() => handleSaveRole(role)}
-                    className={`w-full text-left px-4 py-3 rounded-xl border-2 text-sm font-semibold transition-all ${editUser.userType === role ? 'border-primary-500 bg-primary-50 text-primary-700' : 'border-gray-100 text-gray-600 hover:border-gray-200 hover:bg-gray-50'}`}>
-                    <span className="flex items-center gap-2">
-                      {role === 'admin' && <Shield className="h-4 w-4 text-violet-500" />}
-                      {role} {editUser.userType === role && '(current)'}
-                    </span>
-                  </button>
-                ))}
+              <div className="space-y-4">
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1.5">First name</label>
+                    <input value={form.firstName} onChange={(e) => setForm((p) => ({ ...p, firstName: e.target.value }))} className="input-field" />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1.5">Last name</label>
+                    <input value={form.lastName} onChange={(e) => setForm((p) => ({ ...p, lastName: e.target.value }))} className="input-field" />
+                  </div>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1.5">Phone</label>
+                  <input value={form.phone} onChange={(e) => setForm((p) => ({ ...p, phone: e.target.value }))} className="input-field" />
+                </div>
+              </div>
+              <div className="flex gap-3 mt-6">
+                <button onClick={() => setEditUser(null)} className="btn-secondary flex-1">Cancel</button>
+                <button onClick={handleSave} disabled={saving} className="btn-accent flex-1 disabled:opacity-60">{saving ? 'Saving…' : 'Save Changes'}</button>
               </div>
             </motion.div>
           </motion.div>


### PR DESCRIPTION
## Summary

Replaces the mock data in the admin console with real calls to the now-correct service layer (from the API-wiring PR). The dashboards go from static demos to live tools — and each page only exposes the actions the backend actually supports.

## Pages wired
- **AdminDashboard** — KPI counts (hotels/rooms/reservations/users) and the recent-reservations list come from live data. Each fetch is independent (`Promise.all` with per-call `.catch`) so one failing endpoint doesn't blank the whole board.
- **ManageHotels** — lists from `getAllHotels`; create/update/delete via the service. The create form gains the backend-required **contact email**, and the category select uses the real `hotelType` values.
- **ManageRooms** — lists from `getAllRooms` with a hotel-name lookup (the list endpoint doesn't join the hotel). Create keys off the hotel's **contact email** (the backend `createRoom` contract), category uses the real **ENUM** values, update/delete wired.
- **ManageReservations** — lists from `getAllReservations`; actions are the genuinely supported transitions — **check-in**, **check-out** (dedicated endpoints) and **delete**. Status isn't editable through `update` (stripped server-side by the audit), so there's no fake status dropdown.
- **ManageUsers** — lists from `getAllUsers`; **edit name/phone** and **delete**. No role/suspend controls — role changes are a privilege boundary the backend blocks on this endpoint, so the UI doesn't pretend to offer them.

Every page has loading + empty states and surfaces API errors via toast.

## Design note
Where the backend deliberately restricts something (reservation status is controlled by check-in/out; user roles can't be reassigned via the generic update), I removed the corresponding mock control rather than wire a button that would silently fail. The console now reflects the real capability set.

## Verification
- Client `tsc --noEmit` — clean.

## Notes
- Requires the DB migrations from earlier PRs to be run, and a seeded company/hotel to see data.
- Backend unchanged in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adw1AMH3J1UxbBFuQLJ7MS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Adw1AMH3J1UxbBFuQLJ7MS)_