### PR TITLE
Wire profile & settings pages + avatar image upload

### DIFF
--- a/CLIENT/src/pages/user/ProfilePage.tsx
+++ b/CLIENT/src/pages/user/ProfilePage.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { motion } from 'framer-motion';
 import { useSelector, useDispatch } from 'react-redux';
 import { useForm } from 'react-hook-form';
-import { User, Mail, Phone, Camera, Save, Lock, Eye, EyeOff } from 'lucide-react';
+import { User, Mail, Phone, Camera, Save, Lock, Loader2 } from 'lucide-react';
 import type { RootState } from '../../store';
 import { updateUser } from '../../store/authSlice';
+import { userService, authService, apiService } from '../../services';
 import toast from 'react-hot-toast';
 
 const fadeUp = { hidden: { opacity: 0, y: 16 }, visible: { opacity: 1, y: 0, transition: { duration: 0.4 } } };
@@ -13,9 +14,10 @@ const ProfilePage: React.FC = () => {
   const { user } = useSelector((state: RootState) => state.auth);
   const dispatch = useDispatch();
   const [tab, setTab] = useState<'info' | 'password'>('info');
-  const [showOld, setShowOld] = useState(false);
-  const [showNew, setShowNew] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [sendingReset, setSendingReset] = useState(false);
+  const fileInput = useRef<HTMLInputElement>(null);
 
   const { register, handleSubmit, formState: { errors } } = useForm({
     defaultValues: {
@@ -26,25 +28,56 @@ const ProfilePage: React.FC = () => {
     },
   });
 
-  const { register: registerPw, handleSubmit: handlePwSubmit, reset: resetPw, formState: { errors: pwErrors } } = useForm<{ oldPassword: string; newPassword: string }>();
-
   const onSaveProfile = async (data: any) => {
+    if (!user?.id) return;
     setSaving(true);
-    await new Promise((r) => setTimeout(r, 800));
-    dispatch(updateUser({ firstName: data.firstName, lastName: data.lastName }));
-    toast.success('Profile updated successfully!');
-    setSaving(false);
+    try {
+      await userService.updateUser(user.id, {
+        firstName: data.firstName,
+        lastName: data.lastName,
+        phoneNumber: data.phoneNumber,
+      } as any);
+      dispatch(updateUser({ firstName: data.firstName, lastName: data.lastName, phoneNumber: data.phoneNumber } as any));
+      toast.success('Profile updated successfully!');
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message ?? 'Failed to update profile.');
+    } finally {
+      setSaving(false);
+    }
   };
 
-  const onChangePassword = async (_data: any) => {
-    setSaving(true);
-    await new Promise((r) => setTimeout(r, 800));
-    toast.success('Password updated!');
-    resetPw();
-    setSaving(false);
+  const onPickAvatar = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file || !user?.id) return;
+    setUploading(true);
+    try {
+      const { url } = await apiService.uploadImage(file);
+      await userService.updateUser(user.id, { avatarUrl: url } as any);
+      dispatch(updateUser({ avatarUrl: url } as any));
+      toast.success('Photo updated!');
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message ?? 'Failed to upload photo.');
+    } finally {
+      setUploading(false);
+      if (fileInput.current) fileInput.current.value = '';
+    }
+  };
+
+  const sendResetLink = async () => {
+    if (!user?.email) return;
+    setSendingReset(true);
+    try {
+      await authService.forgotPassword(user.email);
+      toast.success('Password reset link sent to your email.');
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message ?? 'Could not send reset link.');
+    } finally {
+      setSendingReset(false);
+    }
   };
 
   const initials = `${user?.firstName?.[0] ?? ''}${user?.lastName?.[0] ?? ''}`.toUpperCase() || 'U';
+  const avatarUrl = (user as any)?.avatarUrl;
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -53,11 +86,18 @@ const ProfilePage: React.FC = () => {
           <motion.div initial="hidden" animate="visible" variants={fadeUp} className="flex items-center gap-5">
             {/* Avatar */}
             <div className="relative">
-              <div className="w-20 h-20 rounded-2xl bg-gradient-to-br from-primary-500 to-primary-700 flex items-center justify-center text-white text-2xl font-bold">
-                {initials}
+              <div className="w-20 h-20 rounded-2xl bg-gradient-to-br from-primary-500 to-primary-700 flex items-center justify-center text-white text-2xl font-bold overflow-hidden">
+                {avatarUrl ? <img src={avatarUrl} alt="Avatar" className="w-full h-full object-cover" /> : initials}
               </div>
-              <button className="absolute -bottom-1 -right-1 w-7 h-7 bg-white rounded-full border-2 border-gray-200 flex items-center justify-center shadow-sm hover:bg-gray-50 transition-colors">
-                <Camera className="h-3.5 w-3.5 text-gray-500" />
+              <input ref={fileInput} type="file" accept="image/*" className="hidden" onChange={onPickAvatar} />
+              <button
+                type="button"
+                onClick={() => fileInput.current?.click()}
+                disabled={uploading}
+                title="Change photo"
+                className="absolute -bottom-1 -right-1 w-7 h-7 bg-white rounded-full border-2 border-gray-200 flex items-center justify-center shadow-sm hover:bg-gray-50 transition-colors disabled:opacity-60"
+              >
+                {uploading ? <Loader2 className="h-3.5 w-3.5 text-gray-500 animate-spin" /> : <Camera className="h-3.5 w-3.5 text-gray-500" />}
               </button>
             </div>
             <div>
@@ -71,7 +111,7 @@ const ProfilePage: React.FC = () => {
             {(['info', 'password'] as const).map((t) => (
               <button key={t} onClick={() => setTab(t)}
                 className={`px-5 py-2 rounded-xl text-sm font-semibold transition-all ${tab === t ? 'bg-primary-600 text-white' : 'text-gray-500 hover:text-gray-800 hover:bg-gray-100'}`}>
-                {t === 'info' ? 'Personal Info' : 'Change Password'}
+                {t === 'info' ? 'Personal Info' : 'Password'}
               </button>
             ))}
           </div>
@@ -128,41 +168,22 @@ const ProfilePage: React.FC = () => {
 
         {tab === 'password' && (
           <motion.div initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} className="bg-white rounded-2xl border border-gray-100 p-6 max-w-md">
-            <form onSubmit={handlePwSubmit(onChangePassword)} className="space-y-5">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1.5 flex items-center gap-1.5">
-                  <Lock className="h-3.5 w-3.5 text-gray-400" /> Current Password
-                </label>
-                <div className="relative">
-                  <input type={showOld ? 'text' : 'password'} {...registerPw('oldPassword', { required: 'Required' })}
-                    className={`input-field pr-11 ${pwErrors.oldPassword ? 'border-red-400' : ''}`} />
-                  <button type="button" onClick={() => setShowOld(!showOld)} className="absolute right-3.5 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors">
-                    {showOld ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                  </button>
-                </div>
-                {pwErrors.oldPassword && <p className="text-red-500 text-xs mt-1">{pwErrors.oldPassword.message}</p>}
+            <div className="flex items-start gap-3 mb-5">
+              <div className="p-2 bg-primary-50 rounded-xl">
+                <Lock className="h-4 w-4 text-primary-600" />
               </div>
-
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1.5 flex items-center gap-1.5">
-                  <Lock className="h-3.5 w-3.5 text-gray-400" /> New Password
-                </label>
-                <div className="relative">
-                  <input type={showNew ? 'text' : 'password'} {...registerPw('newPassword', { required: 'Required', minLength: { value: 8, message: 'Minimum 8 characters' } })}
-                    placeholder="Min. 8 characters"
-                    className={`input-field pr-11 ${pwErrors.newPassword ? 'border-red-400' : ''}`} />
-                  <button type="button" onClick={() => setShowNew(!showNew)} className="absolute right-3.5 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors">
-                    {showNew ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                  </button>
-                </div>
-                {pwErrors.newPassword && <p className="text-red-500 text-xs mt-1">{pwErrors.newPassword.message}</p>}
+                <h3 className="font-semibold text-gray-900 text-sm">Reset your password</h3>
+                <p className="text-sm text-gray-500 mt-1">
+                  We&apos;ll email a secure link to <span className="font-medium text-gray-700">{user?.email}</span> that lets
+                  you set a new password. The link expires shortly for your security.
+                </p>
               </div>
-
-              <motion.button type="submit" disabled={saving} whileTap={{ scale: 0.98 }} className="btn-primary flex items-center gap-2">
-                {saving ? <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" /> : <Save className="h-4 w-4" />}
-                {saving ? 'Updating…' : 'Update Password'}
-              </motion.button>
-            </form>
+            </div>
+            <motion.button onClick={sendResetLink} disabled={sendingReset} whileTap={{ scale: 0.98 }} className="btn-primary flex items-center gap-2">
+              {sendingReset ? <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" /> : <Mail className="h-4 w-4" />}
+              {sendingReset ? 'Sending…' : 'Send reset link'}
+            </motion.button>
           </motion.div>
         )}
       </div>

--- a/CLIENT/src/pages/user/SettingsPage.tsx
+++ b/CLIENT/src/pages/user/SettingsPage.tsx
@@ -1,12 +1,21 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
-import { Bell, Globe, Shield, Trash2, LogOut } from 'lucide-react';
-import { useDispatch } from 'react-redux';
+import { Bell, Globe, Trash2, LogOut } from 'lucide-react';
+import { useDispatch, useSelector } from 'react-redux';
 import { logout } from '../../store/authSlice';
+import type { RootState } from '../../store';
+import { userService } from '../../services';
 import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 
 const fadeUp = { hidden: { opacity: 0, y: 12 }, visible: { opacity: 1, y: 0, transition: { duration: 0.4 } } };
+
+const NOTIF_KEY = 'stayng.notifs';
+const PREFS_KEY = 'stayng.prefs';
+const loadJSON = <T,>(key: string, fallback: T): T => {
+  try { const v = localStorage.getItem(key); return v ? { ...fallback, ...JSON.parse(v) } : fallback; }
+  catch { return fallback; }
+};
 
 function Toggle({ checked, onChange }: { checked: boolean; onChange: () => void }) {
   return (
@@ -23,13 +32,35 @@ function Toggle({ checked, onChange }: { checked: boolean; onChange: () => void 
 const SettingsPage: React.FC = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const { user } = useSelector((state: RootState) => state.auth);
+  const [deleting, setDeleting] = useState(false);
 
-  const [notifs, setNotifs] = useState({ email: true, sms: false, deals: true, reminders: true });
-  const [prefs, setPrefs] = useState({ currency: 'NGN', language: 'en', darkMode: false });
+  const [notifs, setNotifs] = useState(() => loadJSON(NOTIF_KEY, { email: true, sms: false, deals: true, reminders: true }));
+  const [prefs, setPrefs] = useState(() => loadJSON(PREFS_KEY, { currency: 'NGN', language: 'en', darkMode: false }));
+
+  // Persist preferences locally so they survive reloads.
+  useEffect(() => { localStorage.setItem(NOTIF_KEY, JSON.stringify(notifs)); }, [notifs]);
+  useEffect(() => { localStorage.setItem(PREFS_KEY, JSON.stringify(prefs)); }, [prefs]);
 
   const handleLogout = () => {
     dispatch(logout());
     navigate('/login');
+  };
+
+  const handleDeleteAccount = async () => {
+    if (!user?.id) return;
+    if (!window.confirm('Permanently delete your account? This cannot be undone.')) return;
+    setDeleting(true);
+    try {
+      await userService.deleteUser(user.id);
+      toast.success('Your account has been deleted.');
+      dispatch(logout());
+      navigate('/');
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message ?? 'Could not delete account.');
+    } finally {
+      setDeleting(false);
+    }
   };
 
   const toggleNotif = (key: keyof typeof notifs) => setNotifs((p) => ({ ...p, [key]: !p[key] }));
@@ -109,21 +140,6 @@ const SettingsPage: React.FC = () => {
             </Row>
           </Section>
 
-          {/* Security */}
-          <Section title="Security" icon={Shield}>
-            <Row label="Two-Factor Authentication" desc="Add an extra layer of security to your account">
-              <button className="btn-outline text-xs py-1.5 px-3">Enable</button>
-            </Row>
-            <Row label="Active sessions" desc="Manage devices logged in to your account">
-              <button className="text-xs text-primary-600 hover:text-primary-700 font-semibold transition-colors">Manage</button>
-            </Row>
-            <Row label="Download my data" desc="Get a copy of all your account data">
-              <button onClick={() => toast.success(`Data export requested. You'll receive an email shortly.`)} className="text-xs text-primary-600 hover:text-primary-700 font-semibold transition-colors">
-                Request
-              </button>
-            </Row>
-          </Section>
-
           {/* Danger zone */}
           <motion.div variants={fadeUp} className="bg-white rounded-2xl border border-red-100 overflow-hidden">
             <div className="px-6 py-4 border-b border-red-50 flex items-center gap-3">
@@ -138,8 +154,8 @@ const SettingsPage: React.FC = () => {
                   <p className="text-sm font-medium text-gray-800">Delete Account</p>
                   <p className="text-xs text-gray-400 mt-0.5">Permanently delete your account and all data</p>
                 </div>
-                <button onClick={() => toast.error('Account deletion requires contacting support.')} className="text-xs bg-red-50 hover:bg-red-100 text-red-600 font-semibold px-3 py-1.5 rounded-lg transition-colors">
-                  Delete
+                <button onClick={handleDeleteAccount} disabled={deleting} className="text-xs bg-red-50 hover:bg-red-100 text-red-600 font-semibold px-3 py-1.5 rounded-lg transition-colors disabled:opacity-60">
+                  {deleting ? 'Deleting…' : 'Delete'}
                 </button>
               </div>
               <div className="flex items-center justify-between">

--- a/CLIENT/src/services/api.ts
+++ b/CLIENT/src/services/api.ts
@@ -78,6 +78,16 @@ class ApiService {
     return response.data.data;
   }
 
+  /** Upload an image to the backend and get back its hosted URL. */
+  async uploadImage(file: File): Promise<{ url: string }> {
+    const formData = new FormData();
+    formData.append('image', file);
+    const response = await this.api.post<{ url: string }>('/upload', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+    return response.data;
+  }
+
   async uploadFile<T>(url: string, file: File, additionalData?: Record<string, any>): Promise<T> {
     const formData = new FormData();
     formData.append('image', file);

--- a/CLIENT/src/types/index.ts
+++ b/CLIENT/src/types/index.ts
@@ -15,6 +15,8 @@ export interface User {
   dateOfBirth?: string;
   gender?: 'male' | 'female' | 'other';
   profileImage?: string;
+  avatarUrl?: string;
+  phoneNumber?: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/app.ts
+++ b/app.ts
@@ -21,7 +21,6 @@ import bodyParser from 'body-parser';
 
 import { b2Storage, UploadResult } from './src/shared/services/b2Storage.service';
 import { authentication } from './middleware/authentication';
-import verifyUserType from './middleware/verifyUserType';
 
 import authRoute from './routes/auth';
 import userRoute from './routes/user';
@@ -130,12 +129,11 @@ app.get('/', (_req, res) => {
   res.status(200).json({ message: 'Welcome to Hotel Management Platform!' });
 });
 
-// ── Image upload (authenticated + admin/org_admin only) ───────────────────────
+// ── Image upload (any authenticated user — e.g. profile avatar, hotel photos) ──
 app.post(
-  '/upload',
+  '/api/upload',
   uploadLimiter,
   authentication,
-  verifyUserType(['admin', 'org_admin']),
   upload.single('image'),
   async (req: Request, res: Response): Promise<any> => {
     if (!req.file) {

--- a/migrations/20240101000007-add-avatar-to-users.js
+++ b/migrations/20240101000007-add-avatar-to-users.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/**
+ * Adds an optional avatar image URL to users, set from the profile page after
+ * uploading an image.
+ *
+ * @type {import('sequelize-cli').Migration}
+ */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Users', 'avatarUrl', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Users', 'avatarUrl');
+  },
+};

--- a/models/user.ts
+++ b/models/user.ts
@@ -16,6 +16,7 @@ export interface UserInstance extends Model {
   password: string;
   type?: UserType;
   companyId?: string;
+  avatarUrl?: string;
   readonly createdAt: Date;
   readonly updatedAt: Date;
   readonly deletedAt: Date;
@@ -37,6 +38,7 @@ export default (sequelize: Sequelize, dataTypes: typeof DataTypes): ModelCtor<Us
     password!: string;
     type?: UserType;
     companyId?: string;
+    avatarUrl?: string;
     readonly createdAt!: Date;
     readonly updatedAt!: Date;
     readonly deletedAt!: Date;
@@ -103,6 +105,10 @@ export default (sequelize: Sequelize, dataTypes: typeof DataTypes): ModelCtor<Us
         type: DataTypes.UUID,
         allowNull: true,
         references: { model: 'Companies', key: 'id' },
+      },
+      avatarUrl: {
+        type: DataTypes.STRING,
+        allowNull: true,
       },
     },
     {

--- a/routes/user.ts
+++ b/routes/user.ts
@@ -8,6 +8,8 @@ const router = Router();
 router.get('/alluser', authentication, verifyUserType(['admin', 'org_admin']), findAllUser);
 router.get('/user/:id', authentication, findOne);
 router.put('/updateuser/:id', authentication, updateUser);
-router.delete('/deleteuser/:id', authentication, verifyUserType(['admin']), deleteUser);
+// Scope is enforced in the controller (canAccessUser): platform admin any,
+// org_admin their company, and a user may delete their own account.
+router.delete('/deleteuser/:id', authentication, deleteUser);
 
 export default router;


### PR DESCRIPTION
## Summary

Polish pass: makes the **profile** and **settings** pages functional and wires **image upload** (avatar). Each control is backed by a real endpoint — where the backend doesn't support something, the control was replaced or removed rather than left to silently fail.

## Profile
- **Save personal info** through the real `updateUser` endpoint (was a simulated timeout).
- **Avatar upload** — pick an image → `POST /api/upload` → save the returned URL on the user and display it. Adds `User.avatarUrl` (migration + model).
- The dead **"Change Password"** tab (there is no change-password endpoint) is replaced with a **"Send reset link"** action backed by `/forgot` — honest and working.

## Settings
- Notification + preference toggles **persist to `localStorage`** so they survive reloads.
- **Delete Account** deletes the current user (self) and signs out.
- Removed the **Security** section (2FA / active sessions / data export) — none of it is backend-backed, so it no longer pretends to work.

## Backend
- Moved the image upload route to **`/api/upload`** (reachable from the client's `/api` base) and allowed **any authenticated user** to upload (not just admins), so a guest can set an avatar.
- Relaxed the **delete-user route** to `authentication`; the scope was already enforced in the controller (`canAccessUser` — platform admin any, org_admin own company, or self), which is what lets a user delete their own account.

## Verification
- Backend `tsc --noEmit` — clean.
- Client `tsc --noEmit` — clean.

## Notes
- Adds migration `20240101000007-add-avatar-to-users.js` — run `npm run migrate`.
- Image upload persists to Backblaze B2 (existing `b2Storage`), so it needs the B2 env vars configured to actually store files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adw1AMH3J1UxbBFuQLJ7MS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Adw1AMH3J1UxbBFuQLJ7MS)_