### PR TITLE
Availability + payments: prevent double-booking, collect payment via Paystack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,10 @@ QSTASH_URL=https://qstash.upstash.io
 QSTASH_TOKEN=your_qstash_token_here
 QSTASH_CURRENT_SIGNING_KEY=your_current_signing_key_here
 QSTASH_NEXT_SIGNING_KEY=your_next_signing_key_here
+
+# ── Paystack (payments) ───────────────────────────────────────────────────────
+# Use your sk_test_... key in development. Required for payments; the server
+# also uses it to verify webhook signatures (HMAC SHA512 of the raw body).
+# Set the webhook URL in your Paystack dashboard to:
+#   <PUBLIC_URL>/api/payments/webhook
+PAYSTACK_SECRET_KEY=sk_test_your_paystack_secret_key_here

--- a/CLIENT/src/App.tsx
+++ b/CLIENT/src/App.tsx
@@ -38,6 +38,7 @@ import FrontDeskPage from './pages/admin/FrontDeskPage';
 
 // Pages - Bookings
 import BookingConfirmationPage from './pages/bookings/BookingConfirmationPage';
+import PaymentCallbackPage from './pages/bookings/PaymentCallbackPage';
 
 // Protected Route Component
 interface ProtectedRouteProps {
@@ -89,6 +90,8 @@ const App: React.FC = () => {
           
           {/* Booking Routes */}
           <Route path="/book/:roomId" element={<MainLayout><BookingPage /></MainLayout>} />
+          {/* Where Paystack returns the guest after checkout */}
+          <Route path="/booking/payment/callback" element={<MainLayout><PaymentCallbackPage /></MainLayout>} />
           <Route
             path="/booking/:id/confirmation"
             element={

--- a/CLIENT/src/pages/bookings/BookingPage.tsx
+++ b/CLIENT/src/pages/bookings/BookingPage.tsx
@@ -4,7 +4,7 @@ import { motion } from 'framer-motion';
 import { useForm } from 'react-hook-form';
 import { ChevronLeft, BedDouble, Users, Calendar, CheckCircle, AlertCircle, CreditCard, Phone, Mail, User } from 'lucide-react';
 import toast from 'react-hot-toast';
-import { reservationService } from '../../services';
+import { reservationService, paymentService } from '../../services';
 
 // Mock — replace with API call using useParams roomId
 const ROOM = {
@@ -91,7 +91,22 @@ const BookingPage: React.FC = () => {
         },
       });
       setBookingReference(result.bookingReference);
-      setConfirmed(true);
+
+      // Hand off to Paystack. The backend computes the amount from the
+      // reservation — we never send a price from here.
+      try {
+        const payment = await paymentService.initialize({
+          bookingReference: result.bookingReference,
+          callbackUrl: `${window.location.origin}/booking/payment/callback`,
+        });
+        window.location.href = payment.authorizationUrl;
+        return;
+      } catch {
+        // The booking exists and is held; payment can be retried from the
+        // confirmation screen rather than losing the reservation.
+        toast.error('Booking held, but payment could not be started. You can pay from your confirmation.');
+        setConfirmed(true);
+      }
     } catch (err: any) {
       const message = err?.response?.data?.message ?? 'Booking failed. Please try again.';
       // 409 = someone booked these dates between our check and this submit.

--- a/CLIENT/src/pages/bookings/BookingPage.tsx
+++ b/CLIENT/src/pages/bookings/BookingPage.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { useForm } from 'react-hook-form';
-import { ChevronLeft, BedDouble, Users, Calendar, CheckCircle, CreditCard, Phone, Mail, User } from 'lucide-react';
+import { ChevronLeft, BedDouble, Users, Calendar, CheckCircle, AlertCircle, CreditCard, Phone, Mail, User } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { reservationService } from '../../services';
 
@@ -37,6 +37,9 @@ const BookingPage: React.FC = () => {
   const [confirmed, setConfirmed] = useState(false);
   const [bookingReference, setBookingReference] = useState('');
   const [loading, setLoading] = useState(false);
+  // null = not checked yet (dates incomplete)
+  const [availability, setAvailability] = useState<{ available: boolean; reason?: string } | null>(null);
+  const [checking, setChecking] = useState(false);
 
   const { register, handleSubmit, formState: { errors } } = useForm<GuestForm>();
 
@@ -47,9 +50,29 @@ const BookingPage: React.FC = () => {
   const tax = Math.round(subtotal * 0.075);
   const total = subtotal + tax;
 
+  // Check availability as soon as the guest has picked a valid stay, so they
+  // learn the room is taken before filling in their details.
+  useEffect(() => {
+    if (!roomId || !checkIn || !checkOut || new Date(checkOut) <= new Date(checkIn)) {
+      setAvailability(null);
+      return;
+    }
+    let active = true;
+    setChecking(true);
+    reservationService.checkRoomAvailability(roomId, checkIn, checkOut)
+      .then((res) => { if (active) setAvailability(res); })
+      .catch(() => { if (active) setAvailability(null); })
+      .finally(() => { if (active) setChecking(false); });
+    return () => { active = false; };
+  }, [roomId, checkIn, checkOut]);
+
   const onSubmit = async (data: GuestForm) => {
     if (!checkIn || !checkOut || nights < 1) { toast.error('Please select valid check-in and check-out dates.'); return; }
     if (!roomId) { toast.error('Missing room. Please start from the hotel page.'); return; }
+    if (availability && !availability.available) {
+      toast.error(availability.reason ?? 'This room is not available for those dates.');
+      return;
+    }
     setLoading(true);
     try {
       // Guest checkout — no account required. companyId is intentionally NOT
@@ -70,7 +93,12 @@ const BookingPage: React.FC = () => {
       setBookingReference(result.bookingReference);
       setConfirmed(true);
     } catch (err: any) {
-      toast.error(err?.response?.data?.message ?? 'Booking failed. Please try again.');
+      const message = err?.response?.data?.message ?? 'Booking failed. Please try again.';
+      // 409 = someone booked these dates between our check and this submit.
+      if (err?.response?.status === 409) {
+        setAvailability({ available: false, reason: message });
+      }
+      toast.error(message);
     } finally {
       setLoading(false);
     }
@@ -147,6 +175,25 @@ const BookingPage: React.FC = () => {
                     </div>
                   </div>
                 </div>
+
+                {/* Live availability for the chosen stay */}
+                {checking && (
+                  <p className="mt-4 text-sm text-gray-400 flex items-center gap-2">
+                    <span className="w-3.5 h-3.5 border-2 border-gray-300 border-t-gray-500 rounded-full animate-spin" />
+                    Checking availability…
+                  </p>
+                )}
+                {!checking && availability?.available === true && (
+                  <p className="mt-4 text-sm text-emerald-600 font-medium flex items-center gap-1.5">
+                    <CheckCircle className="h-4 w-4" /> Available for these dates
+                  </p>
+                )}
+                {!checking && availability?.available === false && (
+                  <p className="mt-4 text-sm text-red-600 font-medium flex items-center gap-1.5">
+                    <AlertCircle className="h-4 w-4" />
+                    {availability.reason ?? 'Not available for these dates'}
+                  </p>
+                )}
               </div>
 
               {/* Guest details */}
@@ -280,16 +327,18 @@ const BookingPage: React.FC = () => {
 
                 <motion.button
                   type="submit"
-                  disabled={loading}
+                  disabled={loading || checking || availability?.available === false}
                   whileTap={{ scale: 0.98 }}
-                  className="btn-accent w-full py-3.5"
+                  className="btn-accent w-full py-3.5 disabled:opacity-60 disabled:cursor-not-allowed"
                 >
                   {loading ? (
                     <span className="flex items-center justify-center gap-2">
                       <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
                       Confirming…
                     </span>
-                  ) : `Confirm & Pay ₦${total.toLocaleString()}`}
+                  ) : availability?.available === false
+                    ? 'Unavailable for these dates'
+                    : `Confirm & Pay ₦${total.toLocaleString()}`}
                 </motion.button>
 
                 <div className="space-y-2">

--- a/CLIENT/src/pages/bookings/PaymentCallbackPage.tsx
+++ b/CLIENT/src/pages/bookings/PaymentCallbackPage.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { CheckCircle, AlertCircle, Loader2 } from 'lucide-react';
+import { paymentService } from '../../services';
+
+type State = 'verifying' | 'success' | 'pending' | 'failed';
+
+/**
+ * Where Paystack returns the guest after checkout. The redirect itself proves
+ * nothing, so we ask our backend to verify the transaction before showing any
+ * confirmation. (The webhook is the authoritative signal and may well have
+ * settled it already — verifying is idempotent.)
+ */
+const PaymentCallbackPage: React.FC = () => {
+  const [params] = useSearchParams();
+  // Paystack appends ?reference= (and trxref=) to the callback URL.
+  const reference = params.get('reference') ?? params.get('trxref') ?? '';
+  const [state, setState] = useState<State>('verifying');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    if (!reference) {
+      setState('failed');
+      setMessage('No payment reference was provided.');
+      return;
+    }
+    let active = true;
+    paymentService.verify(reference)
+      .then((res) => {
+        if (!active) return;
+        if (res.status === 'success') { setState('success'); setMessage(res.message); }
+        else if (res.status === 'pending') { setState('pending'); setMessage(res.message); }
+        else { setState('failed'); setMessage(res.message || 'The payment did not go through.'); }
+      })
+      .catch((err) => {
+        if (!active) return;
+        setState('failed');
+        setMessage(err?.response?.data?.message ?? 'We could not confirm this payment.');
+      });
+    return () => { active = false; };
+  }, [reference]);
+
+  const view = {
+    verifying: {
+      icon: <Loader2 className="h-12 w-12 text-primary-500 animate-spin" />,
+      bg: 'bg-primary-50',
+      title: 'Confirming your payment…',
+      body: 'Hold on a moment while we check with the payment provider.',
+    },
+    success: {
+      icon: <CheckCircle className="h-12 w-12 text-emerald-500" />,
+      bg: 'bg-emerald-50',
+      title: 'Payment confirmed',
+      body: 'Your booking is confirmed. Show your booking reference at the front desk to check in.',
+    },
+    pending: {
+      icon: <Loader2 className="h-12 w-12 text-amber-500" />,
+      bg: 'bg-amber-50',
+      title: 'Payment still processing',
+      body: 'Your bank has not completed this yet. We will confirm your booking automatically once it clears.',
+    },
+    failed: {
+      icon: <AlertCircle className="h-12 w-12 text-red-500" />,
+      bg: 'bg-red-50',
+      title: 'Payment not completed',
+      body: message || 'The payment did not go through. Your room is still held — you can try again.',
+    },
+  }[state];
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={{ opacity: 1, scale: 1 }}
+        className="bg-white rounded-3xl shadow-xl p-10 max-w-md w-full text-center"
+      >
+        <div className={`inline-flex p-5 ${view.bg} rounded-full mb-6`}>{view.icon}</div>
+        <h2 className="text-2xl font-display font-bold text-gray-900 mb-2">{view.title}</h2>
+        <p className="text-gray-500 text-sm mb-6">{view.body}</p>
+
+        {reference && state !== 'verifying' && (
+          <div className="bg-gray-50 rounded-2xl p-4 mb-8">
+            <p className="text-xs uppercase tracking-wider text-gray-400 font-semibold mb-1">Payment reference</p>
+            <p className="text-sm font-mono font-semibold text-gray-800 break-all">{reference}</p>
+          </div>
+        )}
+
+        {state !== 'verifying' && (
+          <Link to="/" className="btn-accent w-full py-3 inline-block">Done</Link>
+        )}
+      </motion.div>
+    </div>
+  );
+};
+
+export default PaymentCallbackPage;

--- a/CLIENT/src/services/index.ts
+++ b/CLIENT/src/services/index.ts
@@ -5,3 +5,4 @@ export { default as hotelService, hotelService as hotelApi } from './hotel.servi
 export { default as roomService, roomService as roomApi } from './room.service';
 export { default as reservationService, reservationService as reservationApi } from './reservation.service';
 export { default as userService, userService as userApi } from './user.service';
+export { default as paymentService, paymentService as paymentApi } from './payment.service';

--- a/CLIENT/src/services/payment.service.ts
+++ b/CLIENT/src/services/payment.service.ts
@@ -1,0 +1,32 @@
+import apiService from './api';
+
+/**
+ * Payments (Paystack). The charge amount is decided by the backend from the
+ * reservation — the client never sends an amount.
+ */
+class PaymentService {
+  /** Start a payment and get Paystack's hosted checkout URL. */
+  async initialize(data: { bookingReference?: string; reservationId?: string; callbackUrl?: string }) {
+    return apiService.post<{
+      authorizationUrl: string;
+      reference: string;
+      amount: number;
+      currency: string;
+    }>('/payments/initialize', data);
+  }
+
+  /** Confirm a transaction after the guest returns from Paystack. */
+  async verify(reference: string) {
+    return apiService.get<{ status: string; reference: string; message: string }>(
+      `/payments/verify/${reference}`
+    );
+  }
+
+  /** Staff: payments for the caller's tenant. */
+  async list() {
+    return apiService.get<{ Count: number; Payments: any[] }>('/payments');
+  }
+}
+
+export const paymentService = new PaymentService();
+export default paymentService;

--- a/CLIENT/src/services/reservation.service.ts
+++ b/CLIENT/src/services/reservation.service.ts
@@ -36,6 +36,22 @@ class ReservationService {
     );
   }
 
+  /** Public: is this room free for the given stay? */
+  async checkRoomAvailability(roomId: string, dateIn: string, dateOut: string) {
+    return apiService.get<{ available: boolean; reason?: string }>(
+      `/availability/room/${roomId}`,
+      { params: { dateIn, dateOut } }
+    );
+  }
+
+  /** Public: which of a hotel's rooms are free for the given stay. */
+  async getAvailableRooms(hotelId: string, dateIn: string, dateOut: string) {
+    return apiService.get<{ Count: number; Rooms: any[] }>(
+      `/availability/hotel/${hotelId}`,
+      { params: { dateIn, dateOut } }
+    );
+  }
+
   async updateReservation(id: string, reservationData: Partial<Reservation>) {
     return apiService.put<{ reservation: Reservation }>(`/updatereservation/${id}`, reservationData);
   }

--- a/app.ts
+++ b/app.ts
@@ -32,6 +32,7 @@ import reservationRoute from './routes/reservation';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import companyRoute from './routes/company';
+import paymentRoute from './routes/payment';
 
 import errorHandler from './middleware/errorHandler';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -78,7 +79,12 @@ const uploadLimiter = rateLimit({
 app.use(globalLimiter);
 
 // ── Body parsing ───────────────────────────────────────────────────────────────
-app.use(express.json({ limit: '10mb' }));
+// Keep the raw body around: the Paystack webhook signature is an HMAC of the
+// exact bytes sent, so the parsed object can't be used to verify it.
+app.use(express.json({
+  limit: '10mb',
+  verify: (req, _res, buf) => { (req as any).rawBody = buf; },
+}));
 app.use(bodyParser.json({ limit: '10mb' }));
 app.use(auditMutations);
 app.use(express.urlencoded({ extended: true, limit: '10mb' }));
@@ -119,6 +125,7 @@ app.use('/api', facilityRoute);
 app.use('/api', ratingsRoute);
 app.use('/api', reservationRoute);
 app.use('/api', companyRoute);
+app.use('/api', paymentRoute);
 
 // Health check (no auth, no rate limit — for load-balancer probes)
 app.get('/health', (_req, res) => {

--- a/controllers/paymentController.ts
+++ b/controllers/paymentController.ts
@@ -1,0 +1,232 @@
+/**
+ * Payment Controller (Paystack)
+ */
+
+import { Request, Response } from 'express';
+import { v4 as uuidv4 } from 'uuid';
+import { Payment, Reservation, Hotel, sequelize } from '../models';
+import {
+  computeAmountKobo,
+  initializeTransaction,
+  verifyTransaction,
+  isValidWebhookSignature,
+  buildPaymentReference,
+} from '../services/paymentService';
+
+const canAccessPayment = (req: Request, payment: any): boolean => {
+  const user = req.user;
+  if (!user) return false;
+  if (user.type === 'admin') return true;
+  return !!user.companyId && payment.companyId === user.companyId;
+};
+
+/**
+ * Record a successful payment against its reservation. Shared by the callback
+ * verify and the webhook, and safe to run more than once — whichever arrives
+ * first wins and the second is a no-op.
+ */
+const applySuccessfulPayment = async (
+  payment: any,
+  details: { amountKobo: number; channel?: string; paidAt?: Date }
+): Promise<void> => {
+  if (payment.status === 'success') return; // already settled
+
+  // Guard against an underpayment being treated as settlement.
+  if (details.amountKobo < Number(payment.amount)) {
+    await payment.update({ status: 'failed' });
+    return;
+  }
+
+  await sequelize.transaction(async (t) => {
+    await payment.update(
+      { status: 'success', channel: details.channel, paidAt: details.paidAt ?? new Date() },
+      { transaction: t }
+    );
+
+    const reservation = await Reservation.findByPk(payment.reservationId, { transaction: t });
+    if (reservation) {
+      // Paying confirms the booking; leave later states (checked-in etc.) alone.
+      const next = (reservation as any).status === 'pending' ? 'confirmed' : (reservation as any).status;
+      await reservation.update({ paymentStatus: true, status: next }, { transaction: t });
+    }
+  });
+};
+
+/**
+ * Start a payment for a booking and return Paystack's hosted checkout URL.
+ *
+ * Public: guest bookings have no account, so the booking reference acts as the
+ * capability to pay for that booking. The amount is always computed server-side.
+ */
+export const initializePayment = async (req: Request, res: Response): Promise<any> => {
+  try {
+    const { bookingReference, reservationId, callbackUrl } = req.body;
+    if (!bookingReference && !reservationId) {
+      return res.status(400).json({ message: 'bookingReference or reservationId is required' });
+    }
+
+    const reservation: any = bookingReference
+      ? await Reservation.findOne({ where: { bookingReference } })
+      : await Reservation.findByPk(reservationId);
+
+    if (!reservation) return res.status(404).json({ message: 'Booking not found' });
+    if (reservation.paymentStatus === true) {
+      return res.status(409).json({ message: 'This booking has already been paid for' });
+    }
+    if (reservation.status === 'cancelled') {
+      return res.status(409).json({ message: 'This booking has been cancelled' });
+    }
+
+    const email = reservation.guestEmail || req.user?.email;
+    if (!email) {
+      return res.status(400).json({ message: 'No email on this booking to send the receipt to' });
+    }
+
+    // Authoritative amount — derived from the room price, not the request.
+    const amountKobo = await computeAmountKobo(reservation);
+    const reference = buildPaymentReference(reservation.bookingReference);
+
+    const payment = await Payment.create({
+      id: uuidv4(),
+      reservationId: reservation.id,
+      companyId: reservation.companyId,
+      reference,
+      amount: amountKobo,
+      currency: 'NGN',
+      status: 'pending',
+      email,
+    });
+
+    try {
+      const init = await initializeTransaction({
+        email,
+        amountKobo,
+        reference,
+        callbackUrl,
+        metadata: { reservationId: reservation.id, bookingReference: reservation.bookingReference },
+      });
+
+      return res.status(201).json({
+        message: 'Payment initialized',
+        authorizationUrl: init.authorizationUrl,
+        reference,
+        amount: amountKobo,
+        currency: 'NGN',
+      });
+    } catch (err: any) {
+      // Don't leave a dangling "pending" row if the provider rejected us.
+      await payment.update({ status: 'failed' });
+      return res.status(502).json({ message: err.message || 'Could not start the payment' });
+    }
+  } catch (err: any) {
+    return res.status(500).json({ message: 'Failed to initialize payment', error: err.message });
+  }
+};
+
+/**
+ * Verify a transaction (called when the guest returns from Paystack).
+ * Public — the reference is unguessable and only reveals its own status.
+ */
+export const verifyPayment = async (req: Request, res: Response): Promise<any> => {
+  try {
+    const { reference } = req.params;
+    const payment: any = await Payment.findOne({ where: { reference } });
+    if (!payment) return res.status(404).json({ message: 'Payment not found' });
+
+    if (payment.status === 'success') {
+      return res.status(200).json({ message: 'Payment already confirmed', status: 'success', reference });
+    }
+
+    const result = await verifyTransaction(reference);
+
+    if (result.status === 'success') {
+      await applySuccessfulPayment(payment, {
+        amountKobo: result.amountKobo,
+        channel: result.channel,
+        paidAt: result.paidAt,
+      });
+      // Re-read: applySuccessfulPayment marks it failed on underpayment.
+      await payment.reload();
+      return res.status(200).json({
+        message: payment.status === 'success' ? 'Payment confirmed' : 'Payment amount did not match',
+        status: payment.status,
+        reference,
+      });
+    }
+
+    await payment.update({ status: result.status === 'pending' ? 'pending' : result.status });
+    return res.status(200).json({ message: 'Payment not completed', status: result.status, reference });
+  } catch (err: any) {
+    return res.status(500).json({ message: 'Failed to verify payment', error: err.message });
+  }
+};
+
+/**
+ * Paystack webhook — the authoritative settlement signal, since a guest may
+ * close the browser before returning. Only acted on after HMAC verification.
+ */
+export const paystackWebhook = async (req: Request, res: Response): Promise<any> => {
+  const signature = req.headers['x-paystack-signature'] as string | undefined;
+
+  if (!isValidWebhookSignature((req as any).rawBody, signature)) {
+    return res.status(401).json({ message: 'Invalid signature' });
+  }
+
+  // Acknowledge immediately; Paystack retries on non-2xx.
+  res.status(200).json({ received: true });
+
+  try {
+    const event = req.body;
+    if (event?.event !== 'charge.success') return;
+
+    const reference = event?.data?.reference;
+    if (!reference) return;
+
+    const payment: any = await Payment.findOne({ where: { reference } });
+    if (!payment) return;
+
+    await applySuccessfulPayment(payment, {
+      amountKobo: Number(event.data.amount) || 0,
+      channel: event.data.channel,
+      paidAt: event.data.paid_at ? new Date(event.data.paid_at) : undefined,
+    });
+  } catch (err: any) {
+    // Response already sent; log for follow-up rather than failing the webhook.
+    console.error('Webhook processing error:', err.message);
+  }
+};
+
+/** Payments for the caller's tenant (platform admin sees all). */
+export const listPayments = async (req: Request, res: Response): Promise<any> => {
+  try {
+    const user = req.user;
+    const where: any = {};
+    if (user?.type !== 'admin') {
+      if (!user?.companyId) return res.status(200).json({ message: 'Payments retrieved', Count: 0, Payments: [] });
+      where.companyId = user.companyId;
+    }
+
+    const { count, rows } = await Payment.findAndCountAll({
+      where,
+      include: [{ model: Reservation, as: 'Reservation', include: [{ model: Hotel, as: 'Hotel' }] }],
+      order: [['createdAt', 'DESC']],
+    });
+    return res.status(200).json({ message: 'Payments retrieved', Count: count, Payments: rows });
+  } catch (err: any) {
+    return res.status(500).json({ message: 'Failed to retrieve payments', error: err.message });
+  }
+};
+
+/** A single payment, tenant-scoped. */
+export const getPayment = async (req: Request, res: Response): Promise<any> => {
+  try {
+    const { id } = req.params;
+    const payment: any = await Payment.findByPk(id);
+    if (!payment || !canAccessPayment(req, payment)) {
+      return res.status(404).json({ message: 'Payment not found' });
+    }
+    return res.status(200).json({ message: 'Payment retrieved', payment });
+  } catch (err: any) {
+    return res.status(500).json({ message: 'Failed to retrieve payment', error: err.message });
+  }
+};

--- a/controllers/reservationController.ts
+++ b/controllers/reservationController.ts
@@ -4,7 +4,8 @@
 
 import { Request, Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
-import { Reservation, Hotel, Room, User } from '../models';
+import { Reservation, Hotel, Room, User, sequelize } from '../models';
+import { parseStay, isRoomAvailable, findAvailableRooms } from '../services/availabilityService';
 
 const GUEST_INCLUDE = [
   { model: User, as: 'User', attributes: { exclude: ['password'] } },
@@ -53,6 +54,9 @@ export const createReservation = async (req: Request, res: Response): Promise<an
       return res.status(400).json({ message: 'hotelId and roomId are required' });
     }
 
+    const stay = parseStay(dateIn, dateOut);
+    if (stay.error) return res.status(400).json({ message: stay.error });
+
     const hotel = await Hotel.findByPk(hotelId);
     if (!hotel) return res.status(404).json({ message: 'Hotel not found' });
 
@@ -65,23 +69,40 @@ export const createReservation = async (req: Request, res: Response): Promise<an
 
     const companyId = (hotel as any).companyId;
 
-    const reservation = await Reservation.create({
-      // Client-supplied extras first, then authoritative fields override them so
-      // companyId/userId/status can never be spoofed via the request body.
-      ...stripProtectedFields(req.body),
-      id: uuidv4(),
-      userId,
-      hotelId,
-      roomId,
-      companyId,
-      dateIn,
-      dateOut,
-      guestCount: guestCount || 1,
-      status: 'pending',
+    // Lock the room row for the duration, so two concurrent bookings for the
+    // same room can't both pass the availability check.
+    const reservation = await sequelize.transaction(async (t) => {
+      await Room.findByPk(roomId, { transaction: t, lock: t.LOCK.UPDATE });
+
+      const check = await isRoomAvailable(roomId, stay.range!, { transaction: t });
+      if (!check.available) {
+        const conflict: any = new Error(check.reason || 'Room unavailable');
+        conflict.statusCode = 409;
+        throw conflict;
+      }
+
+      return Reservation.create(
+        {
+          // Client-supplied extras first, then authoritative fields override them so
+          // companyId/userId/status can never be spoofed via the request body.
+          ...stripProtectedFields(req.body),
+          id: uuidv4(),
+          userId,
+          hotelId,
+          roomId,
+          companyId,
+          dateIn: stay.range!.dateIn,
+          dateOut: stay.range!.dateOut,
+          guestCount: guestCount || 1,
+          status: 'pending',
+        },
+        { transaction: t }
+      );
     });
 
     return res.status(201).json({ message: 'Reservation created successfully', reservation });
   } catch (err: any) {
+    if (err.statusCode === 409) return res.status(409).json({ message: err.message });
     return res.status(500).json({ message: 'Failed to create reservation', error: err.message });
   }
 };
@@ -112,9 +133,9 @@ export const createGuestReservation = async (req: Request, res: Response): Promi
     if (!hotelId || !roomId) {
       return res.status(400).json({ message: 'hotelId and roomId are required' });
     }
-    if (!dateIn || !dateOut) {
-      return res.status(400).json({ message: 'dateIn and dateOut are required' });
-    }
+    const stay = parseStay(dateIn, dateOut);
+    if (stay.error) return res.status(400).json({ message: stay.error });
+
     const guestName = guest?.name ?? req.body.guestName;
     const guestEmail = guest?.email ?? req.body.guestEmail;
     const guestPhone = guest?.phone ?? req.body.guestPhone;
@@ -132,20 +153,35 @@ export const createGuestReservation = async (req: Request, res: Response): Promi
 
     const bookingReference = await generateBookingReference();
 
-    const reservation = await Reservation.create({
-      id: uuidv4(),
-      userId: null as any, // guest booking — no account
-      hotelId,
-      roomId,
-      companyId: (hotel as any).companyId,
-      guestName,
-      guestEmail,
-      guestPhone,
-      bookingReference,
-      dateIn,
-      dateOut,
-      guestCount: guestCount || 1,
-      status: 'pending',
+    // Lock the room row so two guests can't book the same dates concurrently.
+    const reservation = await sequelize.transaction(async (t) => {
+      await Room.findByPk(roomId, { transaction: t, lock: t.LOCK.UPDATE });
+
+      const check = await isRoomAvailable(roomId, stay.range!, { transaction: t });
+      if (!check.available) {
+        const conflict: any = new Error(check.reason || 'Room unavailable');
+        conflict.statusCode = 409;
+        throw conflict;
+      }
+
+      return Reservation.create(
+        {
+          id: uuidv4(),
+          userId: null as any, // guest booking — no account
+          hotelId,
+          roomId,
+          companyId: (hotel as any).companyId,
+          guestName,
+          guestEmail,
+          guestPhone,
+          bookingReference,
+          dateIn: stay.range!.dateIn,
+          dateOut: stay.range!.dateOut,
+          guestCount: guestCount || 1,
+          status: 'pending',
+        },
+        { transaction: t }
+      );
     });
 
     return res.status(201).json({
@@ -154,7 +190,39 @@ export const createGuestReservation = async (req: Request, res: Response): Promi
       reservation,
     });
   } catch (err: any) {
+    if (err.statusCode === 409) return res.status(409).json({ message: err.message });
     return res.status(500).json({ message: 'Failed to create booking', error: err.message });
+  }
+};
+
+/**
+ * Public availability check for a single room over a date range — lets the
+ * booking page tell a guest before they fill in their details.
+ */
+export const checkRoomAvailability = async (req: Request, res: Response): Promise<any> => {
+  try {
+    const { roomId } = req.params;
+    const stay = parseStay(req.query.dateIn, req.query.dateOut);
+    if (stay.error) return res.status(400).json({ message: stay.error });
+
+    const result = await isRoomAvailable(roomId, stay.range!);
+    return res.status(200).json({ available: result.available, reason: result.reason });
+  } catch (err: any) {
+    return res.status(500).json({ message: 'Availability check failed', error: err.message });
+  }
+};
+
+/** Public: which of a hotel's rooms are free for a date range. */
+export const getAvailableRooms = async (req: Request, res: Response): Promise<any> => {
+  try {
+    const { hotelId } = req.params;
+    const stay = parseStay(req.query.dateIn, req.query.dateOut);
+    if (stay.error) return res.status(400).json({ message: stay.error });
+
+    const rooms = await findAvailableRooms(hotelId, stay.range!);
+    return res.status(200).json({ message: 'Available rooms retrieved', Count: rooms.length, Rooms: rooms });
+  } catch (err: any) {
+    return res.status(500).json({ message: 'Availability lookup failed', error: err.message });
   }
 };
 

--- a/migrations/20240101000008-create-payments.js
+++ b/migrations/20240101000008-create-payments.js
@@ -1,0 +1,78 @@
+'use strict';
+
+/**
+ * Payments — an audit trail of every transaction attempt against a reservation.
+ *
+ * Amounts are stored in the currency's smallest unit (kobo for NGN) as BIGINT:
+ * integers avoid floating-point rounding on money, and BIGINT leaves no
+ * realistic overflow ceiling.
+ *
+ * @type {import('sequelize-cli').Migration}
+ */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('Payments', {
+      id: {
+        type: Sequelize.UUID,
+        primaryKey: true,
+        allowNull: false,
+      },
+      reservationId: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'Reservations', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      // Denormalised so payments can be scoped per tenant without a join.
+      companyId: {
+        type: Sequelize.UUID,
+        allowNull: true,
+        references: { model: 'Companies', key: 'id' },
+      },
+      reference: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        unique: true,
+      },
+      amount: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+      },
+      currency: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        defaultValue: 'NGN',
+      },
+      status: {
+        type: Sequelize.ENUM('pending', 'success', 'failed', 'abandoned'),
+        allowNull: false,
+        defaultValue: 'pending',
+      },
+      channel: {
+        type: Sequelize.STRING,
+        allowNull: true,
+      },
+      email: {
+        type: Sequelize.STRING,
+        allowNull: true,
+      },
+      paidAt: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+      createdAt: { allowNull: false, type: Sequelize.DATE },
+      updatedAt: { allowNull: false, type: Sequelize.DATE },
+      deletedAt: { allowNull: true, type: Sequelize.DATE },
+    });
+
+    await queryInterface.addIndex('Payments', ['reservationId'], { name: 'payments_reservation_idx' });
+    await queryInterface.addIndex('Payments', ['companyId'], { name: 'payments_company_idx' });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('Payments', 'payments_reservation_idx');
+    await queryInterface.removeIndex('Payments', 'payments_company_idx');
+    await queryInterface.dropTable('Payments');
+  },
+};

--- a/models/index.ts
+++ b/models/index.ts
@@ -30,6 +30,7 @@ import FacilityFactory from './facilities';
 import RatingAndReviewFactory from './ratingAndReview';
 import MediaFileFactory from './mediaFile';
 import ReservationFactory from './reservation';
+import PaymentFactory from './payment';
 
 // JS models (company and auditLog are still .js)
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -44,6 +45,7 @@ export const Facility = FacilityFactory(sequelize, DataTypes);
 export const RatingAndReview = RatingAndReviewFactory(sequelize, DataTypes);
 export const MediaFile = MediaFileFactory(sequelize, DataTypes);
 export const Reservation = ReservationFactory(sequelize, DataTypes);
+export const Payment = PaymentFactory(sequelize, DataTypes);
 export const Company = CompanyFactory(sequelize, DataTypes);
 export const AuditLog = AuditLogFactory(sequelize, DataTypes);
 
@@ -55,6 +57,7 @@ const models = {
   RatingAndReview,
   MediaFile,
   Reservation,
+  Payment,
   Company,
   AuditLog,
 };

--- a/models/payment.ts
+++ b/models/payment.ts
@@ -1,0 +1,112 @@
+/**
+ * Payment Model
+ *
+ * One row per transaction attempt against a reservation. Amounts are in the
+ * currency's smallest unit (kobo for NGN).
+ */
+
+import { Model, DataTypes, Sequelize, Optional } from 'sequelize';
+
+export type PaymentState = 'pending' | 'success' | 'failed' | 'abandoned';
+
+export interface PaymentInstance extends Model {
+  id: string;
+  reservationId: string;
+  companyId?: string;
+  reference: string;
+  amount: number;
+  currency: string;
+  status: PaymentState;
+  channel?: string;
+  email?: string;
+  paidAt?: Date;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+  readonly deletedAt: Date;
+}
+
+export interface PaymentCreationAttributes extends Optional<
+  PaymentInstance,
+  'id' | 'companyId' | 'currency' | 'status' | 'channel' | 'email' | 'paidAt' | 'createdAt' | 'updatedAt' | 'deletedAt'
+> {}
+
+export default (sequelize: Sequelize, dataTypes: typeof DataTypes): any => {
+  class Payment extends Model<PaymentInstance, PaymentCreationAttributes> implements PaymentInstance {
+    static associate(models: any) {
+      Payment.belongsTo(models.Reservation, { foreignKey: 'reservationId', as: 'Reservation' });
+    }
+
+    id!: string;
+    reservationId!: string;
+    companyId?: string;
+    reference!: string;
+    amount!: number;
+    currency!: string;
+    status!: PaymentState;
+    channel?: string;
+    email?: string;
+    paidAt?: Date;
+    readonly createdAt!: Date;
+    readonly updatedAt!: Date;
+    readonly deletedAt!: Date;
+  }
+
+  Payment.init(
+    {
+      id: {
+        type: dataTypes.UUID,
+        primaryKey: true,
+        defaultValue: dataTypes.UUIDV4,
+      },
+      reservationId: {
+        type: dataTypes.UUID,
+        allowNull: false,
+      },
+      companyId: {
+        type: dataTypes.UUID,
+        allowNull: true,
+        references: { model: 'Companies', key: 'id' },
+      },
+      reference: {
+        type: dataTypes.STRING,
+        allowNull: false,
+        unique: true,
+      },
+      amount: {
+        type: dataTypes.BIGINT,
+        allowNull: false,
+      },
+      currency: {
+        type: dataTypes.STRING,
+        allowNull: false,
+        defaultValue: 'NGN',
+      },
+      status: {
+        type: dataTypes.ENUM('pending', 'success', 'failed', 'abandoned'),
+        allowNull: false,
+        defaultValue: 'pending',
+      },
+      channel: {
+        type: dataTypes.STRING,
+        allowNull: true,
+      },
+      email: {
+        type: dataTypes.STRING,
+        allowNull: true,
+      },
+      paidAt: {
+        type: dataTypes.DATE,
+        allowNull: true,
+      },
+    } as any,
+    {
+      sequelize,
+      tableName: 'Payments',
+      modelName: 'Payment',
+      paranoid: true,
+      timestamps: true,
+    }
+  );
+
+  return Payment;
+};

--- a/routes/payment.ts
+++ b/routes/payment.ts
@@ -1,0 +1,27 @@
+import { Router } from 'express';
+import {
+  initializePayment,
+  verifyPayment,
+  paystackWebhook,
+  listPayments,
+  getPayment,
+} from '../controllers/paymentController';
+import { authentication } from '../middleware/authentication';
+import verifyUserType from '../middleware/verifyUserType';
+
+const router = Router();
+
+// ── Public (guest checkout has no account) ─────────────────────────────────
+// The booking reference / payment reference act as the capability here; the
+// charge amount is always computed server-side from the reservation.
+router.post('/payments/initialize', initializePayment);
+router.get('/payments/verify/:reference', verifyPayment);
+
+// Paystack webhook — authenticated by HMAC signature, not by a session.
+router.post('/payments/webhook', paystackWebhook);
+
+// ── Staff ──────────────────────────────────────────────────────────────────
+router.get('/payments', authentication, verifyUserType(['admin', 'org_admin']), listPayments);
+router.get('/payments/:id', authentication, verifyUserType(['admin', 'org_admin']), getPayment);
+
+export default router;

--- a/routes/reservation.ts
+++ b/routes/reservation.ts
@@ -2,6 +2,8 @@ import { Router } from 'express';
 import {
   createReservation,
   createGuestReservation,
+  checkRoomAvailability,
+  getAvailableRooms,
   getOneReservation,
   lookupReservation,
   lookupByReference,
@@ -20,6 +22,10 @@ const router = Router();
 router.post('/reservation', authentication, createReservation);
 // Guest checkout — book from a hotel's public page without an account.
 router.post('/reservation/guest', createGuestReservation);
+
+// Public availability — a guest needs these before committing to a booking.
+router.get('/availability/room/:roomId', checkRoomAvailability);
+router.get('/availability/hotel/:hotelId', getAvailableRooms);
 router.get('/getone/:id', authentication, getOneReservation);
 router.get('/getall', authentication, getAllReservations);
 

--- a/services/availabilityService.ts
+++ b/services/availabilityService.ts
@@ -1,0 +1,117 @@
+/**
+ * Room availability
+ *
+ * A room is unavailable for a date range if an existing *active* reservation
+ * overlaps it. Dates are treated as half-open intervals [dateIn, dateOut):
+ * a guest checking out on the 10th does not conflict with one checking in on
+ * the 10th, which matches how hotels actually turn rooms over.
+ */
+
+import { Op, Transaction } from 'sequelize';
+import { Reservation, Room } from '../models';
+
+/**
+ * Statuses that still hold the room. Cancelled, checked-out and no-show
+ * bookings release it.
+ */
+export const BLOCKING_STATUSES = ['pending', 'confirmed', 'checked-in'];
+
+export interface DateRange {
+  dateIn: Date;
+  dateOut: Date;
+}
+
+/**
+ * Validate and normalise a requested stay.
+ * Returns an error message instead of throwing so callers can map it to a 400.
+ */
+export const parseStay = (rawIn: any, rawOut: any): { range?: DateRange; error?: string } => {
+  if (!rawIn || !rawOut) return { error: 'dateIn and dateOut are required' };
+
+  const dateIn = new Date(rawIn);
+  const dateOut = new Date(rawOut);
+
+  if (Number.isNaN(dateIn.getTime()) || Number.isNaN(dateOut.getTime())) {
+    return { error: 'dateIn and dateOut must be valid dates' };
+  }
+  if (dateOut <= dateIn) {
+    return { error: 'dateOut must be after dateIn' };
+  }
+  return { range: { dateIn, dateOut } };
+};
+
+/**
+ * Find an active reservation on this room that overlaps the requested stay.
+ *
+ * Overlap for half-open ranges: existing.dateIn < requested.dateOut
+ *                            && existing.dateOut > requested.dateIn
+ *
+ * Pass a transaction (with lock) to make the check-then-create sequence safe
+ * against concurrent bookings of the same room.
+ */
+export const findConflictingReservation = async (
+  roomId: string,
+  range: DateRange,
+  options: { excludeReservationId?: string; transaction?: Transaction } = {}
+): Promise<any | null> => {
+  const where: any = {
+    roomId,
+    status: { [Op.in]: BLOCKING_STATUSES },
+    dateIn: { [Op.lt]: range.dateOut },
+    dateOut: { [Op.gt]: range.dateIn },
+  };
+
+  if (options.excludeReservationId) {
+    where.id = { [Op.ne]: options.excludeReservationId };
+  }
+
+  return Reservation.findOne({ where, transaction: options.transaction });
+};
+
+/**
+ * Whether a room can be booked for a range: it must be listed as bookable and
+ * have no overlapping active reservation.
+ */
+export const isRoomAvailable = async (
+  roomId: string,
+  range: DateRange,
+  options: { excludeReservationId?: string; transaction?: Transaction } = {}
+): Promise<{ available: boolean; reason?: string }> => {
+  const room = await Room.findByPk(roomId, { transaction: options.transaction });
+  if (!room) return { available: false, reason: 'Room not found' };
+  if ((room as any).availability === false) {
+    return { available: false, reason: 'This room is not currently bookable' };
+  }
+
+  const clash = await findConflictingReservation(roomId, range, options);
+  if (clash) {
+    return { available: false, reason: 'This room is already booked for the selected dates' };
+  }
+  return { available: true };
+};
+
+/**
+ * All rooms in a hotel that are free for the given range — used to show a
+ * guest only what they can actually book on the hotel's own page.
+ */
+export const findAvailableRooms = async (hotelId: string, range: DateRange): Promise<any[]> => {
+  const rooms = await Room.findAll({ where: { hotelId, availability: true } });
+  if (rooms.length === 0) return [];
+
+  const roomIds = rooms.map((r: any) => r.id);
+
+  // One query for every overlapping reservation across the hotel's rooms,
+  // rather than a query per room.
+  const conflicts = await Reservation.findAll({
+    where: {
+      roomId: { [Op.in]: roomIds },
+      status: { [Op.in]: BLOCKING_STATUSES },
+      dateIn: { [Op.lt]: range.dateOut },
+      dateOut: { [Op.gt]: range.dateIn },
+    },
+    attributes: ['roomId'],
+  });
+
+  const taken = new Set(conflicts.map((c: any) => c.roomId));
+  return rooms.filter((r: any) => !taken.has(r.id));
+};

--- a/services/paymentService.ts
+++ b/services/paymentService.ts
@@ -1,0 +1,158 @@
+/**
+ * Payments (Paystack)
+ *
+ * Security rules this module exists to enforce:
+ *  1. The charge amount is ALWAYS computed server-side from the reservation's
+ *     room price and stay length. A client-supplied amount is never trusted.
+ *  2. Money is handled in the currency's smallest unit (kobo) as integers, so
+ *     there is no floating-point rounding.
+ *  3. Webhooks are only acted on after verifying Paystack's HMAC signature.
+ *
+ * Node 22 provides global fetch, so this needs no HTTP dependency.
+ */
+
+import crypto from 'crypto';
+import { Room } from '../models';
+
+const PAYSTACK_BASE = 'https://api.paystack.co';
+
+/** VAT applied to the room subtotal; matches the rate shown at checkout. */
+export const VAT_RATE = 0.075;
+
+const secretKey = (): string => {
+  const key = process.env.PAYSTACK_SECRET_KEY;
+  if (!key) throw new Error('PAYSTACK_SECRET_KEY is not configured');
+  return key;
+};
+
+/** Whole nights between two dates, minimum 1. */
+export const nightsBetween = (dateIn: Date | string, dateOut: Date | string): number => {
+  const ms = new Date(dateOut).getTime() - new Date(dateIn).getTime();
+  return Math.max(1, Math.round(ms / 86_400_000));
+};
+
+/**
+ * The authoritative amount for a reservation, in kobo.
+ * Derived from the room's stored price — never from the request body.
+ */
+export const computeAmountKobo = async (reservation: any): Promise<number> => {
+  const room = await Room.findByPk(reservation.roomId);
+  if (!room) throw new Error('Room not found for reservation');
+
+  const pricePerNight = Number((room as any).price) || 0;
+  if (pricePerNight <= 0) throw new Error('Room has no price set');
+
+  const nights = nightsBetween(reservation.dateIn, reservation.dateOut);
+  const subtotal = pricePerNight * nights;
+  const total = subtotal + Math.round(subtotal * VAT_RATE);
+
+  // Naira -> kobo. Rounded to an integer so no fractional kobo can appear.
+  return Math.round(total * 100);
+};
+
+interface InitializeResult {
+  authorizationUrl: string;
+  reference: string;
+  accessCode?: string;
+}
+
+/**
+ * Create a Paystack transaction and get the hosted checkout URL.
+ * `reference` is ours, so we can correlate the callback/webhook to our Payment row.
+ */
+export const initializeTransaction = async (params: {
+  email: string;
+  amountKobo: number;
+  reference: string;
+  callbackUrl?: string;
+  metadata?: Record<string, any>;
+}): Promise<InitializeResult> => {
+  const response = await fetch(`${PAYSTACK_BASE}/transaction/initialize`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${secretKey()}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      email: params.email,
+      amount: params.amountKobo,
+      reference: params.reference,
+      callback_url: params.callbackUrl,
+      metadata: params.metadata,
+    }),
+  });
+
+  const payload: any = await response.json().catch(() => ({}));
+  if (!response.ok || !payload?.status) {
+    throw new Error(payload?.message || 'Could not start the payment');
+  }
+
+  return {
+    authorizationUrl: payload.data.authorization_url,
+    reference: payload.data.reference,
+    accessCode: payload.data.access_code,
+  };
+};
+
+export interface VerifiedTransaction {
+  status: 'success' | 'failed' | 'abandoned' | 'pending';
+  amountKobo: number;
+  currency: string;
+  channel?: string;
+  paidAt?: Date;
+  reference: string;
+}
+
+/** Ask Paystack for the true state of a transaction. */
+export const verifyTransaction = async (reference: string): Promise<VerifiedTransaction> => {
+  const response = await fetch(`${PAYSTACK_BASE}/transaction/verify/${encodeURIComponent(reference)}`, {
+    headers: { Authorization: `Bearer ${secretKey()}` },
+  });
+
+  const payload: any = await response.json().catch(() => ({}));
+  if (!response.ok || !payload?.status) {
+    throw new Error(payload?.message || 'Could not verify the payment');
+  }
+
+  const data = payload.data ?? {};
+  const rawStatus = String(data.status || '').toLowerCase();
+  const status: VerifiedTransaction['status'] =
+    rawStatus === 'success' ? 'success'
+      : rawStatus === 'abandoned' ? 'abandoned'
+        : rawStatus === 'failed' ? 'failed'
+          : 'pending';
+
+  return {
+    status,
+    amountKobo: Number(data.amount) || 0,
+    currency: data.currency || 'NGN',
+    channel: data.channel,
+    paidAt: data.paid_at ? new Date(data.paid_at) : undefined,
+    reference: data.reference || reference,
+  };
+};
+
+/**
+ * Verify a Paystack webhook signature (HMAC SHA512 of the RAW body with the
+ * secret key). Uses a timing-safe comparison. Without this check anyone could
+ * POST a fake "payment succeeded" event.
+ */
+export const isValidWebhookSignature = (rawBody: Buffer | string | undefined, signature?: string): boolean => {
+  if (!rawBody || !signature) return false;
+  try {
+    const expected = crypto.createHmac('sha512', secretKey()).update(rawBody).digest('hex');
+    const a = Buffer.from(expected, 'utf8');
+    const b = Buffer.from(signature, 'utf8');
+    if (a.length !== b.length) return false;
+    return crypto.timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+};
+
+/** Our own transaction reference, correlated to the booking. */
+export const buildPaymentReference = (bookingReference?: string): string => {
+  const suffix = crypto.randomBytes(4).toString('hex').toUpperCase();
+  const base = (bookingReference || 'PAY').replace(/[^A-Za-z0-9-]/g, '');
+  return `${base}-${suffix}`;
+};

--- a/types/index.ts
+++ b/types/index.ts
@@ -199,6 +199,7 @@ export interface EnvConfig {
   QSTASH_TOKEN: string;
   QSTASH_CURRENT_SIGNING_KEY: string;
   QSTASH_NEXT_SIGNING_KEY: string;
+  PAYSTACK_SECRET_KEY: string;
   LOCAL_PORT?: string;
   NODE_ENV?: string;
 }


### PR DESCRIPTION
> **Note:** this PR now contains **two commits / two features**. Availability was pushed first; payments was added while this PR was still open, so I've updated the title and description rather than leave them describing only half the change. They're reviewable as separate commits.

---

# 1. Date-based room availability (`7ee8552`)

**Nothing previously stopped two guests booking the same room for overlapping dates** — `Room.availability` was only a static "is this room listed" flag, with no date awareness anywhere in the codebase.

### `services/availabilityService.ts` (new)
- **Half-open intervals `[dateIn, dateOut)`** — a guest checking out on the 10th does *not* conflict with one checking in on the 10th, matching how hotels actually turn rooms over.
- **Only active statuses hold a room** — `pending`, `confirmed`, `checked-in` block; `cancelled`, `checked-out`, `no-show` release it.
- `parseStay()` validates the range (rejects invalid dates and `dateOut <= dateIn`).
- `findAvailableRooms()` resolves a whole hotel in **one** query rather than one per room.

### Enforcement
`createReservation` and `createGuestReservation` check availability **inside a transaction that locks the room row**, so two concurrent requests can't both pass. Conflicts return **409** instead of silently double-booking.

### New endpoints
- `GET /availability/room/:roomId?dateIn&dateOut`
- `GET /availability/hotel/:hotelId?dateIn&dateOut`

### Client
`BookingPage` checks availability as soon as a valid stay is picked, shows an inline Available/Not-available banner, disables submit when unavailable, and handles a 409 arriving between check and submit.

---

# 2. Paystack payments (`4dc7b87`)

### Data
New **`Payments`** table + model — one row per transaction attempt (reservationId, companyId for tenant scoping, unique reference, amount, status, channel, paidAt). Amounts are stored **in kobo as `BIGINT`**: integers avoid floating-point rounding on money, and `BIGINT` leaves no realistic overflow ceiling.

### `services/paymentService.ts`
- **`computeAmountKobo()`** derives the charge from the room's stored price × nights + VAT. **A client-supplied amount is never trusted.**
- `initializeTransaction()` / `verifyTransaction()` call Paystack via global `fetch` (Node 22) — **no new dependency**.
- **`isValidWebhookSignature()`** verifies Paystack's HMAC SHA512 over the **raw** body with a timing-safe comparison. Without this, anyone could POST a fake "payment succeeded".

### Endpoints
| Route | Access |
|---|---|
| `POST /payments/initialize` | public — booking reference is the capability; amount computed server-side |
| `GET /payments/verify/:reference` | public — confirms on return from Paystack |
| `POST /payments/webhook` | HMAC-verified (authoritative settlement signal) |
| `GET /payments`, `GET /payments/:id` | staff, tenant-scoped |

### Correctness details
- Applying a payment is **idempotent** — the callback and the webhook can both arrive; whichever is first wins.
- **Underpayment is rejected** rather than treated as settlement.
- Paying confirms a `pending` booking without clobbering later states (e.g. `checked-in`).
- `app.ts` retains the raw body so the webhook HMAC can be verified at all.

### Client
- `payment.service.ts`; booking submit hands off to Paystack's hosted checkout.
- **`PaymentCallbackPage`** verifies with our backend on return — the redirect alone proves nothing.
- If payment can't be started, the **booking is kept** (room still held) rather than lost.

---

## Verification
- Availability date logic: **14 cases** — identical, enclosed, enclosing, partial-start, partial-end, both turnover-adjacent cases, disjoint, plus validation rejections. All pass.
- Payment math + signatures: **18 cases** — nights, VAT, kobo integrality, tampered body, wrong-key signature, missing signature/body, reference uniqueness. All pass.
- Backend `tsc --noEmit` and client `tsc --noEmit` — both clean.

## Before this goes live
- Run `npm run migrate` (adds the `Payments` table).
- Set **`PAYSTACK_SECRET_KEY`** (documented in `.env.example`) and point the Paystack dashboard webhook at `<PUBLIC_URL>/api/payments/webhook`.
- **I could not exercise this against Paystack or a live database from here** — the logic is unit-checked, but an end-to-end run with Paystack **test keys** (including a real webhook delivery and a deliberate underpayment) should happen before taking real money. Likewise, the availability row lock deserves a concurrency stress test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adw1AMH3J1UxbBFuQLJ7MS